### PR TITLE
Add RHEL builds and collect libs

### DIFF
--- a/.github/scripts/install_dependencies_rhel.sh
+++ b/.github/scripts/install_dependencies_rhel.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# yum group install -y "Development Tools"
+# yum install -y gcc gcc-c++ git wget openssl-devel
+# yum install -y epel-release
+# yum install -q -y cmake tar bzip2 gzip gcc gcc-c++ make fftw-devel python3-pip doxygen graphviz
+yum install -q -y fftw-devel python3-pip
+yum install -y centos-release-scl
+yum install -y devtoolset-7-gcc-c++ --enablerepo='centos-sclo-rh'
+scl enable devtoolset-7 'bash'
+gcc --version
+
+source scl_source enable devtoolset-7
+gcc --version
+
+pip3 install -r requirements_test.txt
+pip3 install -r requirements_doc.txt

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -53,6 +53,12 @@ jobs:
           cp bindings\c\src\Release\* tests\Release\
           ctest -V -C Release
 
+      - name: Archive generated DLLs
+        uses: actions/upload-artifact@v2
+        with:
+          name: DLLs
+          path: src\Release\
+
   BuildWindowsInstaller:
     runs-on: windows-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI Pushes
+name: Linux and macOS Builds
 
 on: [push, pull_request]
 
@@ -9,6 +9,13 @@ jobs:
       fail-fast: false
       matrix:
         images: ["debian:buster", "debian:bullseye", "ubuntu:20.04"]
+        include:
+          - images: "debian:buster"
+            label: "Debian_10"
+          - images: "debian:bullseye"
+            label: "Debian_11"
+          - images: "ubuntu:20.04"
+            label: "Ubuntu_20_04"
 
     container:
       image: ${{ matrix.images }}
@@ -30,6 +37,59 @@ jobs:
           cmake -DBUILD_TESTS_EXAMPLES=ON ..
           make -j4
           make test ARGS="-VV"
+          cd ..
+          mkdir -p libs
+          cp build/bindings/c/src/libgenalyzer.so* libs/
+          cp build/src/libgenalyzer_plus_plus.a* libs/
+          cp bindings/c/include/cgenalyzer.h libs/
+          cp bindings/c/include/cgenalyzer_advanced.h libs/
+          cp bindings/python/genalyzer.py libs/
+          cp bindings/python/genalyzer_advanced.py libs/
+          cp bindings/matlab/genalyzer.m libs/
+
+      - name: Archive generated SOs
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.label }}-Build
+          path: libs/
+
+  TestCCentOS:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        images: ["tfcollins/libiio_centos_7-ci:latest"]
+
+    container:
+      image: ${{ matrix.images }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          bash ./.github/scripts/install_dependencies_rhel.sh
+
+      - name: Build and test
+        run: |
+          mkdir -p build
+          cd build
+          source scl_source enable devtoolset-7 && cmake -DBUILD_TESTS_EXAMPLES=ON ..
+          make -j4
+          make test ARGS="-VV"
+          cd ..
+          mkdir -p libs
+          cp build/bindings/c/src/libgenalyzer.so* libs/
+          cp build/src/libgenalyzer_plus_plus.a* libs/
+          cp bindings/c/include/cgenalyzer.h libs/
+          cp bindings/c/include/cgenalyzer_advanced.h libs/
+          cp bindings/python/genalyzer.py libs/
+          cp bindings/python/genalyzer_advanced.py libs/
+          cp bindings/matlab/genalyzer.m libs/
+
+      - name: Archive generated SOs
+        uses: actions/upload-artifact@v2
+        with:
+          name: RHEL_7-Build
+          path: libs/
 
   CoverageTest:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,14 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(CMAKE_CXX_FLAGS
         "${CMAKE_CXX_FLAGS} -std=gnu++17 -fext-numeric-literals")
+    # If GCC is older than 8.0.0, enable experimental filesystem
+    execute_process(
+      COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+    if(GCC_VERSION VERSION_LESS 8.0.0)
+      message(STATUS "GCC version < 8.0.0, enabling experimental filesystem")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++fs")
+      add_definitions(-DEXPERIMENTAL_FILESYSTEM=1)
+    endif()
   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/bindings/c/src/CMakeLists.txt
+++ b/bindings/c/src/CMakeLists.txt
@@ -14,6 +14,17 @@ if(COVERAGE)
   target_link_libraries(genalyzer PRIVATE --coverage)
 endif()
 
+if(UNIX)
+  # If GCC is older than 8.0.0, enable experimental filesystem
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+  if(GCC_VERSION VERSION_LESS 8.0.0)
+    message(STATUS "GCC version < 8.0.0, enabling experimental filesystem")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++fs")
+    target_compile_definitions(genalyzer PUBLIC EXPERIMENTAL_FILESYSTEM)
+  endif()
+endif()
+
 set_target_properties(genalyzer PROPERTIES
   VERSION ${CMAKE_PROJECT_VERSION}
   SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}

--- a/include/json.hpp
+++ b/include/json.hpp
@@ -3949,9 +3949,12 @@ T conditional_static_cast(U value)
 
 // #include <nlohmann/detail/value_t.hpp>
 
-
 #ifdef JSON_HAS_CPP_17
+#ifdef EXPERIMENTAL_FILESYSTEM
+    #include <experimental/filesystem>
+#else
     #include <filesystem>
+#endif
 #endif
 
 namespace nlohmann
@@ -4380,6 +4383,17 @@ void from_json(const BasicJsonType& j, std::unordered_map<Key, Value, Hash, KeyE
 }
 
 #ifdef JSON_HAS_CPP_17
+#ifdef EXPERIMENTAL_FILESYSTEM
+template<typename BasicJsonType>
+void from_json(const BasicJsonType& j, std::experimental::filesystem::path& p)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_string()))
+    {
+        JSON_THROW(type_error::create(302, "type must be string, but is " + std::string(j.type_name()), j));
+    }
+    p = *j.template get_ptr<const typename BasicJsonType::string_t*>();
+}
+#else
 template<typename BasicJsonType>
 void from_json(const BasicJsonType& j, std::filesystem::path& p)
 {
@@ -4389,6 +4403,7 @@ void from_json(const BasicJsonType& j, std::filesystem::path& p)
     }
     p = *j.template get_ptr<const typename BasicJsonType::string_t*>();
 }
+#endif
 #endif
 
 struct from_json_fn
@@ -4627,7 +4642,11 @@ class tuple_element<N, ::nlohmann::detail::iteration_proxy_value<IteratorType >>
 
 
 #ifdef JSON_HAS_CPP_17
+#ifdef EXPERIMENTAL_FILESYSTEM
+    #include <experimental/filesystem>
+#else
     #include <filesystem>
+#endif
 #endif
 
 namespace nlohmann
@@ -5003,11 +5022,19 @@ void to_json(BasicJsonType& j, const T& t)
 }
 
 #ifdef JSON_HAS_CPP_17
+#ifdef EXPERIMENTAL_FILESYSTEM
+template<typename BasicJsonType>
+void to_json(BasicJsonType& j, const std::experimental::filesystem::path& p)
+{
+    j = p.string();
+}
+#else
 template<typename BasicJsonType>
 void to_json(BasicJsonType& j, const std::filesystem::path& p)
 {
     j = p.string();
 }
+#endif
 #endif
 
 struct to_json_fn


### PR DESCRIPTION
This PR does two things:
1. Adds RHEL 7 support as its needed for internal development. This required some changes to CMake and use of the std::filesystem support. Another CI stage was added for RHEL specifically
2. Packages the built libraries into artifacts for easy testing