### PR TITLE
Replace mermaid with pyd2lang-native for Sphinx diagrams

### DIFF
--- a/doc/_ext/conftest.py
+++ b/doc/_ext/conftest.py
@@ -1,0 +1,5 @@
+# doc/_ext/conftest.py
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))

--- a/doc/_ext/sphinxcontrib_d2.css
+++ b/doc/_ext/sphinxcontrib_d2.css
@@ -1,0 +1,37 @@
+/* Overrides for the adi_doctools cosmic theme's .only-light / .only-dark
+ * rules, which force `display: inline-block` (intended for logo <img> tags).
+ * Diagram wrappers need `display: block` so the inline SVG has a definite
+ * parent width to size against; otherwise max-width:100% + height:auto
+ * collapse the SVG to 0 x 0. */
+.d2-diagram.only-light,
+.d2-diagram.only-dark {
+    display: block !important;
+    margin: 1em 0;
+    text-align: center;
+}
+
+.d2-diagram.only-dark {
+    display: none !important;
+}
+
+body.dark .d2-diagram.only-light {
+    display: none !important;
+}
+
+body.dark .d2-diagram.only-dark {
+    display: block !important;
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.light) .d2-diagram.only-light {
+        display: none !important;
+    }
+    body:not(.light) .d2-diagram.only-dark {
+        display: block !important;
+    }
+}
+
+.d2-diagram > svg {
+    max-width: 100%;
+    height: auto;
+}

--- a/doc/_ext/sphinxcontrib_d2.py
+++ b/doc/_ext/sphinxcontrib_d2.py
@@ -1,0 +1,179 @@
+"""Sphinx directive that renders d2 diagrams via pyd2lang-native.
+
+Registers ``.. d2::`` and emits dual-theme (light + dark) SVGs wrapped in
+``only-light`` / ``only-dark`` divs provided by the adi_doctools cosmic theme.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import pathlib
+import re
+import shutil
+import tempfile
+
+import d2
+from docutils import nodes
+from sphinx.application import Sphinx
+from sphinx.errors import ExtensionError
+from sphinx.util.docutils import SphinxDirective
+
+_CSS_FILENAME = "sphinxcontrib_d2.css"
+_CSS_SOURCE = pathlib.Path(__file__).with_name(_CSS_FILENAME)
+
+
+_XML_PROLOG_RE = re.compile(r"^\s*<\?xml[^?]*\?>\s*", re.DOTALL)
+_ROOT_SVG_OPEN_RE = re.compile(r"<svg\b([^>]*)>", re.IGNORECASE)
+_ID_ATTR_RE = re.compile(r'\bid="([^"]+)"')
+
+
+def _rewrite_root_svg(match: "re.Match[str]") -> str:
+    """Strip width/height/fill from the root <svg> and inject responsive style."""
+    attrs = match.group(1)
+    attrs = re.sub(r'\s+(width|height|fill)="[^"]*"', "", attrs)
+
+    responsive = "max-width:100%;height:auto"
+    style_match = re.search(r'style="([^"]*)"', attrs)
+    if style_match:
+        existing = style_match.group(1).rstrip(";")
+        new_style = f'style="{existing};{responsive}"' if existing else f'style="{responsive}"'
+        attrs = attrs[: style_match.start()] + new_style + attrs[style_match.end() :]
+    else:
+        attrs = attrs.rstrip() + f' style="{responsive}"'
+    return f"<svg{attrs}>"
+
+
+def _rewrite_ids(svg: str, nonce: str) -> str:
+    """Prefix every id/url(#…)/href="#…" in the SVG with ``nonce-``.
+
+    Replacements are supplied as lambdas so ``re.sub`` never interprets
+    backslash escapes in ``nonce-{id}`` (e.g., an id like ``\\1x`` would
+    otherwise be seen as a backreference).
+    """
+    ids = set(_ID_ATTR_RE.findall(svg))
+    for original in ids:
+        replacement = f"{nonce}-{original}"
+        escaped = re.escape(original)
+        svg = re.sub(
+            rf'\bid="{escaped}"',
+            lambda m, r=replacement: f'id="{r}"',
+            svg,
+        )
+        svg = re.sub(
+            rf"url\(#{escaped}\)",
+            lambda m, r=replacement: f"url(#{r})",
+            svg,
+        )
+        svg = re.sub(
+            rf'(xlink:)?href="#{escaped}"',
+            lambda m, r=replacement: f'{m.group(1) or ""}href="#{r}"',
+            svg,
+        )
+    return svg
+
+
+def _post_process(svg: str, nonce: str) -> str:
+    """Prepare a raw d2 SVG for inline HTML embedding."""
+    svg = _XML_PROLOG_RE.sub("", svg)
+    svg = _ROOT_SVG_OPEN_RE.sub(_rewrite_root_svg, svg, count=1)
+    svg = _rewrite_ids(svg, nonce)
+    return svg
+
+
+def _compile_raw(source: str, theme: str) -> str:
+    """Compile d2 source with the SW library at a given theme.
+
+    Raises RuntimeError if the compiler returns an error string or None.
+    """
+    svg = d2.compile(source, library="sw", theme=theme)
+    if svg is None:
+        raise RuntimeError(f"d2.compile returned None for theme={theme!r}")
+    if svg.startswith("Error"):
+        raise RuntimeError(svg)
+    return svg
+
+
+def _compile_raw_cached(source: str, theme: str, cache_dir: pathlib.Path) -> str:
+    """Return raw d2 SVG for (source, theme), using an on-disk cache.
+
+    Writes are atomic (temp-file + ``os.replace``) so parallel Sphinx
+    workers that race on the same cache entry never leave a partial file
+    visible to readers.
+    """
+    cache_dir = pathlib.Path(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    key_src = f"{theme}\n{source}".encode("utf-8")
+    digest = hashlib.sha256(key_src).hexdigest()
+    cache_file = cache_dir / f"{digest}.svg"
+    if cache_file.exists():
+        return cache_file.read_text(encoding="utf-8")
+
+    svg = _compile_raw(source, theme=theme)
+    tmp_fd, tmp_path = tempfile.mkstemp(prefix=f".{digest}.", suffix=".svg.tmp", dir=cache_dir)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            fh.write(svg)
+        os.replace(tmp_path, cache_file)
+    except Exception:
+        # Best-effort cleanup if replace never ran.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    return svg
+
+
+def _render_diagram(source: str, cache_dir: pathlib.Path, diagram_index: int) -> str:
+    """Compile source for both themes and return an HTML fragment with both SVGs."""
+    pieces: list[str] = []
+    for theme in ("light", "dark"):
+        try:
+            raw = _compile_raw_cached(source, theme=theme, cache_dir=cache_dir)
+        except RuntimeError as exc:
+            raise ExtensionError(f"d2 compile failed ({theme}): {exc}") from exc
+        nonce = f"d2-{diagram_index}-{theme}"
+        svg = _post_process(raw, nonce=nonce)
+        pieces.append(f'<div class="d2-diagram only-{theme}">{svg}</div>')
+    return "\n".join(pieces)
+
+
+class D2Directive(SphinxDirective):
+    """Render an inline d2 diagram via pyd2lang-native."""
+
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 0
+    final_argument_whitespace = False
+
+    def run(self) -> list[nodes.Node]:
+        source = "\n".join(self.content)
+        env = self.env
+        counter = env.temp_data.setdefault("d2_diagram_counter", 0)
+        env.temp_data["d2_diagram_counter"] = counter + 1
+
+        cache_dir = pathlib.Path(env.app.outdir).parent / ".d2-cache"
+        html = _render_diagram(source, cache_dir=cache_dir, diagram_index=counter)
+        return [nodes.raw("", html, format="html")]
+
+
+def _install_css(app: Sphinx) -> None:
+    """Copy the extension's CSS into the HTML build's ``_static`` directory."""
+    if app.builder.name != "html":
+        return
+    dst_dir = pathlib.Path(app.outdir) / "_static"
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(_CSS_SOURCE, dst_dir / _CSS_FILENAME)
+
+
+def setup(app: Sphinx) -> dict:
+    app.add_directive("d2", D2Directive)
+    app.connect("builder-inited", _install_css)
+    app.add_css_file(_CSS_FILENAME)
+    return {
+        "version": "0.1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/_ext/test_sphinxcontrib_d2.py
+++ b/doc/_ext/test_sphinxcontrib_d2.py
@@ -1,0 +1,105 @@
+# doc/_ext/test_sphinxcontrib_d2.py
+import pytest
+
+pytest.importorskip("d2")
+
+
+def test_compile_raw_returns_svg_for_light_and_dark():
+    from sphinxcontrib_d2 import _compile_raw
+
+    light = _compile_raw("a -> b", theme="light")
+    dark = _compile_raw("a -> b", theme="dark")
+
+    assert "<svg" in light
+    assert "</svg>" in light
+    assert "<svg" in dark
+    assert "</svg>" in dark
+
+
+def test_post_process_strips_xml_prolog_and_adds_responsive_style():
+    from sphinxcontrib_d2 import _compile_raw, _post_process
+
+    raw = _compile_raw("a -> b", theme="light")
+    assert raw.startswith("<?xml"), "sanity: d2 emits an XML prolog"
+
+    out = _post_process(raw, nonce="n1")
+
+    assert not out.lstrip().startswith("<?xml")
+    assert out.lstrip().startswith("<svg")
+    assert "max-width:100%" in out[:300]
+    assert "height:auto" in out[:300]
+
+
+def _extract_ids(svg: str) -> set[str]:
+    import re
+
+    return set(re.findall(r'\bid="([^"]+)"', svg))
+
+
+def test_post_process_isolates_ids_per_nonce():
+    from sphinxcontrib_d2 import _compile_raw, _post_process
+
+    raw = _compile_raw("a -> b", theme="light")
+    first = _post_process(raw, nonce="n1")
+    second = _post_process(raw, nonce="n2")
+
+    first_ids = _extract_ids(first)
+    second_ids = _extract_ids(second)
+
+    assert first_ids, "post-processed SVG should have some id= attributes"
+    assert first_ids.isdisjoint(second_ids), (
+        f"expected disjoint id sets, got intersection={first_ids & second_ids}"
+    )
+    # Every id from the first run must start with its nonce prefix.
+    assert all(i.startswith("n1-") for i in first_ids)
+    assert all(i.startswith("n2-") for i in second_ids)
+
+    import re as _re
+
+    first_urls = set(_re.findall(r"url\(#([^)]+)\)", first))
+    second_urls = set(_re.findall(r"url\(#([^)]+)\)", second))
+    # Every url(#…) reference that points to an id we rewrote must carry the nonce.
+    # (Some CSS url(#…) refs may point to non-id constructs; we only assert the nonced ones.)
+    first_nonced_urls = {u for u in first_urls if u.startswith("n1-")}
+    second_nonced_urls = {u for u in second_urls if u.startswith("n2-")}
+    assert first_nonced_urls.isdisjoint(second_nonced_urls)
+
+    first_hrefs = set(_re.findall(r'href="#([^"]+)"', first))
+    second_hrefs = set(_re.findall(r'href="#([^"]+)"', second))
+    first_nonced_hrefs = {h for h in first_hrefs if h.startswith("n1-")}
+    second_nonced_hrefs = {h for h in second_hrefs if h.startswith("n2-")}
+    assert first_nonced_hrefs.isdisjoint(second_nonced_hrefs)
+
+
+def test_compile_raw_cached_uses_disk_cache(tmp_path, monkeypatch):
+    from sphinxcontrib_d2 import _compile_raw_cached
+
+    calls = {"n": 0}
+
+    def fake_compile(code, *, library=None, theme="light"):
+        calls["n"] += 1
+        return f"<svg theme={theme} code={code}></svg>"
+
+    import sphinxcontrib_d2 as ext
+    monkeypatch.setattr(ext.d2, "compile", fake_compile)
+
+    first = _compile_raw_cached("a -> b", theme="light", cache_dir=tmp_path)
+    second = _compile_raw_cached("a -> b", theme="light", cache_dir=tmp_path)
+
+    assert first == second
+    assert calls["n"] == 1, "second call should hit the cache"
+    # A different theme should miss the cache and invoke d2 again.
+    _compile_raw_cached("a -> b", theme="dark", cache_dir=tmp_path)
+    assert calls["n"] == 2
+
+
+def test_render_diagram_produces_dual_themed_divs(tmp_path):
+    from sphinxcontrib_d2 import _render_diagram
+
+    html = _render_diagram("a -> b", cache_dir=tmp_path, diagram_index=0)
+
+    assert html.count("<svg") >= 2, "expected both light and dark SVGs inline"
+    assert 'class="d2-diagram only-light"' in html
+    assert 'class="d2-diagram only-dark"' in html
+    # Indices differ so nonces differ between the two themes.
+    assert html.index("only-light") < html.index("only-dark")

--- a/doc/_static/genalyzer_overrides.css
+++ b/doc/_static/genalyzer_overrides.css
@@ -1,0 +1,12 @@
+/* Index-page hero logo: center in the viewport, not in .bodywrapper.
+ *
+ * The cosmic theme shifts .bodywrapper left of the viewport center by
+ * exactly 10vw in the 65em-105em range to make room for the right-side
+ * "On this page" TOC. Counter that shift for the hero logo so it reads
+ * as viewport-centered; outside this range the body is already centered
+ * and no shift is applied. */
+@media (min-width: 65em) and (max-width: 105em) {
+    img.hero-logo {
+        transform: translateX(10vw);
+    }
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,6 +15,7 @@ import sys
 sys.path.insert(0, os.path.abspath('../bindings/c/include'))
 sys.path.insert(0, os.path.abspath('../bindings/python'))
 sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "_ext"))
 
 # Generate API page for documentation
 from gen_api_page import gen_pages
@@ -41,7 +42,7 @@ extensions = [
     "myst_parser",
     "sphinx_inline_tabs",
     "sphinx.ext.graphviz",
-    "sphinxcontrib.mermaid",
+    "sphinxcontrib_d2",
     "sphinx_togglebutton",
     "adi_doctools",
     "sphinx_click.ext",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -81,6 +81,8 @@ html_favicon = "_static/genalyzer_favicon.png"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+html_css_files = ["genalyzer_overrides.css"]
+
 # Breathe Configuration
 breathe_projects = { "Genalyzer": "../doxygen/xml" }
 breathe_default_project = "Genalyzer"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,12 +7,12 @@ genalyzer: Data Converter Library
 =================================
 
 .. image:: _static/genalyzer_logo_dark.png
-   :class: only-dark
+   :class: only-dark hero-logo
    :width: 500px
    :alt: Genalyzer Logo
 
 .. image:: _static/genalyzer_logo.png
-   :class: only-light
+   :class: only-light hero-logo
    :width: 500px
    :alt: Genalyzer Logo
 

--- a/doc/mcp/index.md
+++ b/doc/mcp/index.md
@@ -60,29 +60,40 @@ All tools read `.npy` or `.csv` inputs (auto-detected by extension). Every `anal
 ## Pipeline
 
 ```{eval-rst}
-.. mermaid::
+.. d2::
 
-   graph LR;
-     G1[generate_test_tone] --> Q[quantize];
-     G2[generate_real_tone] --> Q;
-     G3[generate_ramp] --> Q;
-     G4[generate_gaussian_noise] --> Q;
-     Q --> CF[compute_fft];
-     Q --> CH[compute_histogram];
-     CH --> CD[compute_dnl];
-     CD --> CI[compute_inl];
-     CF --> FM[get_fa_metrics];
-     Q --> AS[analyze_spectrum];
-     Q --> AH[analyze_histogram];
-     Q --> AD[analyze_dnl];
-     Q --> AI[analyze_inl];
-     Q --> AW[analyze_waveform];
+   direction: right
 
-     style AS fill:#9fa4fc
-     style AH fill:#9fa4fc
-     style AD fill:#9fa4fc
-     style AI fill:#9fa4fc
-     style AW fill:#9fa4fc
+   G1: generate_test_tone      { class: sw-step-white }
+   G2: generate_real_tone      { class: sw-step-white }
+   G3: generate_ramp           { class: sw-step-white }
+   G4: generate_gaussian_noise { class: sw-step-white }
+   Q:  quantize                { class: sw-step-white }
+   CF: compute_fft             { class: sw-step-white }
+   CH: compute_histogram       { class: sw-step-white }
+   CD: compute_dnl             { class: sw-step-white }
+   CI: compute_inl             { class: sw-step-white }
+   FM: get_fa_metrics          { class: sw-step-white }
+   AS: analyze_spectrum        { class: sw-step-blue }
+   AH: analyze_histogram       { class: sw-step-blue }
+   AD: analyze_dnl             { class: sw-step-blue }
+   AI: analyze_inl             { class: sw-step-blue }
+   AW: analyze_waveform        { class: sw-step-blue }
+
+   G1 -> Q  { class: sw-flow }
+   G2 -> Q  { class: sw-flow }
+   G3 -> Q  { class: sw-flow }
+   G4 -> Q  { class: sw-flow }
+   Q -> CF  { class: sw-flow-data }
+   Q -> CH  { class: sw-flow-data }
+   CH -> CD { class: sw-flow-data }
+   CD -> CI { class: sw-flow-data }
+   CF -> FM { class: sw-flow-data }
+   Q -> AS  { class: sw-flow-data }
+   Q -> AH  { class: sw-flow-data }
+   Q -> AD  { class: sw-flow-data }
+   Q -> AI  { class: sw-flow-data }
+   Q -> AW  { class: sw-flow-data }
 ```
 
 ## See also

--- a/doc/spectral_analysis.md
+++ b/doc/spectral_analysis.md
@@ -3,37 +3,41 @@ In this tutorial, we will use Genalyzer to conduct spectral analysis of a wavefo
 
 The workflow we follow in this tutorial is generally what is to be followed to use Genalyzer for spectral analysis. It consists of three stages shown in the diagram below.
 
-```{eval-rst} 
-.. mermaid::
+```{eval-rst}
+.. d2::
 
-    graph LR;      
-        A[Generate/Import Waveform] --> B[Compute FFT];
-        B -->C1[Configure Spectral Analysis];
+    direction: right
 
-        subgraph SA[Spectral Analysis]
-          C1[Configure] -->C2[Run];
-        end
-
-        style SA fill:#ffffff
+    A: Generate/Import Waveform { class: sw-step-white }
+    B: Compute FFT              { class: sw-step-white }
+    SA: Spectral Analysis {
+      class: sw-container
+      C1: Configure { class: sw-step-white }
+      C2: Run       { class: sw-step-white }
+      C1 -> C2 { class: sw-flow }
+    }
+    A -> B     { class: sw-flow }
+    B -> SA.C1 { class: sw-flow }
 ```
 
 We first generate (or import) a waveform to be analyzed, compute its FFT, and finally, calculate various performance metrics by running spectral analysis. In this tutorial, we will generate the tone waveform using Genalyzer. Please refer to the [spectral-analysis example](https://github.com/analogdevicesinc/genalyzer/blob/main/bindings/python/examples/gn_doc_spectral_analysis1.py) Python script to follow the discussion on this page.
 
 ## Tone Generation
-```{eval-rst} 
-.. mermaid::
+```{eval-rst}
+.. d2::
 
-    graph LR;      
-        A[Generate/Import Waveform] --> B[Compute FFT];
-        B -->C1[Configure Spectral Analysis];
+    direction: right
 
-        subgraph SA[Spectral Analysis]
-          C1[Configure] -->C2[Run];
-        end
-
-        style SA fill:#ffffff
-
-        style A fill:#9fa4fc
+    A: Generate/Import Waveform { class: sw-step-blue }
+    B: Compute FFT              { class: sw-step-white }
+    SA: Spectral Analysis {
+      class: sw-container
+      C1: Configure { class: sw-step-white }
+      C2: Run       { class: sw-step-white }
+      C1 -> C2 { class: sw-flow }
+    }
+    A -> B     { class: sw-flow }
+    B -> SA.C1 { class: sw-flow }
 ```
 Genalyzer supports [sine](#genalyzer.sin), [cosine](#genalyzer.cos), [ramp](#genalyzer.ramp), and [Gaussian](#genalyzer.gaussian) random waveforms. It also contains a [waveform analysis](#genalyzer.wf_analysis) utility to summarize a waveform, generated or otherwise. For example, in the [spectral-analysis example](https://github.com/analogdevicesinc/genalyzer/blob/main/bindings/python/examples/gn_doc_spectral_analysis1.py) Python script, to generate a cosine-waveform, we called [``cos()``](#genalyzer.cos) as follows:
 ```{code-block} python
@@ -67,20 +71,21 @@ Time-domain plot of a ``300 KHz`` complex sinusoidal tone sampled at ``3 MSPS``.
 ```
 
 ## Compute FFT
-```{eval-rst} 
-.. mermaid::
+```{eval-rst}
+.. d2::
 
-    graph LR;      
-        A[Generate/Import Waveform] --> B[Compute FFT];
-        B -->C1[Configure Spectral Analysis];
+    direction: right
 
-        subgraph SA[Spectral Analysis]
-          C1[Configure] -->C2[Run];
-        end
-
-        style SA fill:#ffffff
-
-      style B fill:#9fa4fc
+    A: Generate/Import Waveform { class: sw-step-white }
+    B: Compute FFT              { class: sw-step-blue }
+    SA: Spectral Analysis {
+      class: sw-container
+      C1: Configure { class: sw-step-white }
+      C2: Run       { class: sw-step-white }
+      C1 -> C2 { class: sw-flow }
+    }
+    A -> B     { class: sw-flow }
+    B -> SA.C1 { class: sw-flow }
 ```
 Next, we compute FFT of the sinusoidal tone since spectral analysis of a waveform is in essence an analysis of its FFT. 
 
@@ -135,35 +140,40 @@ FFT plot of a ``300 KHz`` complex sinusoidal tone sampled at ``3 MSPS``.
 ```
 
 ## Run Spectral Analysis
-```{eval-rst} 
-.. mermaid::
+```{eval-rst}
+.. d2::
 
-    graph LR;      
-        A[Generate/Import Waveform] --> B[Compute FFT];
-        B -->C1[Configure Spectral Analysis];
+    direction: right
 
-        subgraph SA[Spectral Analysis]
-          C1[Configure] -->C2[Run];
-        end
-
-      style SA fill:#9fa4fc
+    A: Generate/Import Waveform { class: sw-step-white }
+    B: Compute FFT              { class: sw-step-white }
+    SA: Spectral Analysis {
+      class: sw-container
+      C1: Configure { class: sw-step-blue }
+      C2: Run       { class: sw-step-blue }
+      C1 -> C2 { class: sw-flow }
+    }
+    A -> B     { class: sw-flow }
+    B -> SA.C1 { class: sw-flow }
 ```
 Conducting spectral analysis using Genalyzer involves two steps: configuration and analysis. 
 
 ### Configure Genalyzer
-```{eval-rst} 
-.. mermaid::
+```{eval-rst}
+.. d2::
 
-    graph LR;      
-        A[Generate/Import Waveform] --> B[Compute FFT];
-        B -->C1[Configure Spectral Analysis];
+    direction: right
 
-        subgraph SA[Spectral Analysis]
-          C1[Configure] -->C2[Run];
-        end
-
-      style C1 fill:#9fa4fc
-      style SA fill:#ffffff
+    A: Generate/Import Waveform { class: sw-step-white }
+    B: Compute FFT              { class: sw-step-white }
+    SA: Spectral Analysis {
+      class: sw-container
+      C1: Configure { class: sw-step-blue }
+      C2: Run       { class: sw-step-white }
+      C1 -> C2 { class: sw-flow }
+    }
+    A -> B     { class: sw-flow }
+    B -> SA.C1 { class: sw-flow }
 ```
 We configure Genalyzer for spectral analysis by creating a _test_ followed by associating _components_ to this _test_. 
 #### Create a _test_
@@ -197,19 +207,21 @@ Genalyzer supports several _tags_ for Fourier analysis. See [here](#genalyzer.Fa
 The number of single-side bins (SSBs) for a _component_ is an important configuration step, and it will be explained in sufficient detail in another subsection. 
 
 ### Run Spectral Analysis
-```{eval-rst} 
-.. mermaid::
+```{eval-rst}
+.. d2::
 
-    graph LR;      
-        A[Generate/Import Waveform] --> B[Compute FFT];
-        B -->C1[Configure Spectral Analysis];
+    direction: right
 
-        subgraph SA[Spectral Analysis]
-          C1[Configure] -->C2[Run];
-        end
-
-      style C2 fill:#9fa4fc
-      style SA fill:#ffffff
+    A: Generate/Import Waveform { class: sw-step-white }
+    B: Compute FFT              { class: sw-step-white }
+    SA: Spectral Analysis {
+      class: sw-container
+      C1: Configure { class: sw-step-white }
+      C2: Run       { class: sw-step-blue }
+      C1 -> C2 { class: sw-flow }
+    }
+    A -> B     { class: sw-flow }
+    B -> SA.C1 { class: sw-flow }
 ```
 
 In the [spectral-analyis example](https://github.com/analogdevicesinc/genalyzer/blob/main/bindings/python/examples/gn_doc_spectral_analysis1.py) Python script, FFT analysis is run by the following line:

--- a/doc/spectral_analysis_ssb.md
+++ b/doc/spectral_analysis_ssb.md
@@ -3,36 +3,37 @@ In this tutorial, we study a common scenario that arises when spectral analysis 
 
 To recap, we follow a three-stage workflow in Genalyzer as shown below.
 ```{eval-rst} 
-.. mermaid::
+.. d2::
 
-    graph LR;      
-        A[Generate/Import Waveform] --> B[Compute FFT];
-        B -->C1[Configure Spectral Analysis];
-
-        subgraph SA[Spectral Analysis]
-          C1[Configure] -->C2[Run];
-        end
-
-        style SA fill:#ffffff
+    direction: right
+    A: Generate/Import Waveform { class: sw-step-white }
+    B: Compute FFT              { class: sw-step-white }
+    SA: Spectral Analysis {
+      class: sw-container
+      C1: Configure { class: sw-step-white }
+      C2: Run       { class: sw-step-white }
+      C1 -> C2 { class: sw-flow }
+    }
+    A -> B     { class: sw-flow }
+    B -> SA.C1 { class: sw-flow }
 ```
 We will first generate the waveform to be analyzed, compute its FFT, and calculate various performance metrics by running spectral analysis. Please refer to the [leakage and spectral-analysis example](https://github.com/analogdevicesinc/genalyzer/blob/main/bindings/python/examples/gn_doc_spectral_analysis2.py) Python script to follow the discussion on this page.
 
 ## Leakage
 ```{eval-rst} 
-.. mermaid::
+.. d2::
 
-    graph LR;      
-        A[Generate/Import Waveform] --> B[Compute FFT];
-        B -->C1[Configure Spectral Analysis];
-
-        subgraph SA[Spectral Analysis]
-          C1[Configure] -->C2[Run];
-        end
-
-        style SA fill:#ffffff
-
-        style A fill:#9fa4fc        
-        style B fill:#9fa4fc
+    direction: right
+    A: Generate/Import Waveform { class: sw-step-blue }
+    B: Compute FFT              { class: sw-step-blue }
+    SA: Spectral Analysis {
+      class: sw-container
+      C1: Configure { class: sw-step-white }
+      C2: Run       { class: sw-step-white }
+      C1 -> C2 { class: sw-flow }
+    }
+    A -> B     { class: sw-flow }
+    B -> SA.C1 { class: sw-flow }
 ```
 In the [leakage and spectral-analysis example](https://github.com/analogdevicesinc/genalyzer/blob/main/bindings/python/examples/gn_doc_spectral_analysis2.py) Python script, we generate the complex-sinusoidal waveform as follows:
 ```{code-block} python
@@ -106,18 +107,19 @@ When computing the FFT of a waveform to which a window function has been applied
 ## Spectral Analysis
 ### Configure Single Side Bins
 ```{eval-rst} 
-.. mermaid::
+.. d2::
 
-    graph LR;      
-        A[Generate/Import Waveform] --> B[Compute FFT];
-        B -->C1[Configure Spectral Analysis];
-
-        subgraph SA[Spectral Analysis]
-          C1[Configure] -->C2[Run];
-        end
-
-      style C1 fill:#9fa4fc
-      style SA fill:#ffffff
+    direction: right
+    A: Generate/Import Waveform { class: sw-step-white }
+    B: Compute FFT              { class: sw-step-white }
+    SA: Spectral Analysis {
+      class: sw-container
+      C1: Configure { class: sw-step-blue }
+      C2: Run       { class: sw-step-white }
+      C1 -> C2 { class: sw-flow }
+    }
+    A -> B     { class: sw-flow }
+    B -> SA.C1 { class: sw-flow }
 ```
 Even though leakage has been minimized, the tone is not as sharp as when the snapshot of the waveform were periodic. This can be observed by zooming into the region around the ``375 KHz`` tone. This is shown in the plot below.
 ```{figure} figures/fft4.png
@@ -149,18 +151,19 @@ Note that, we set ``ssb_fund`` to ``6`` and ``ssb_dc`` to ``3``. These choices a
 
 ### Run
 ```{eval-rst} 
-.. mermaid::
+.. d2::
 
-    graph LR;      
-        A[Generate/Import Waveform] --> B[Compute FFT];
-        B -->C1[Configure Spectral Analysis];
-
-        subgraph SA[Spectral Analysis]
-          C1[Configure] -->C2[Run];
-        end
-
-      style C2 fill:#9fa4fc
-      style SA fill:#ffffff
+    direction: right
+    A: Generate/Import Waveform { class: sw-step-white }
+    B: Compute FFT              { class: sw-step-white }
+    SA: Spectral Analysis {
+      class: sw-container
+      C1: Configure { class: sw-step-white }
+      C2: Run       { class: sw-step-blue }
+      C1 -> C2 { class: sw-flow }
+    }
+    A -> B     { class: sw-flow }
+    B -> SA.C1 { class: sw-flow }
 ```
 Next, we run FFT analysis in the [leakage and spectral-analysis example](https://github.com/analogdevicesinc/genalyzer/blob/main/bindings/python/examples/gn_doc_spectral_analysis2.py) Python script as follows:
 ```{code-block} python

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,7 +1,7 @@
 sphinx>=5.0
 myst-parser
 https://github.com/analogdevicesinc/doctools/releases/download/latest/adi-doctools.tar.gz
-sphinxcontrib-mermaid
+pyd2lang-native==0.1.1
 sphinx-togglebutton
 sphinx_inline_tabs
 sphinx-click


### PR DESCRIPTION
## Summary

- Replaces `sphinxcontrib-mermaid` with a local Sphinx extension (`doc/_ext/sphinxcontrib_d2.py`, ~170 LOC) that renders d2 diagrams in-process via [`pyd2lang-native`](https://github.com/tfcollins/pyd2lang-native), using the SW component library and dual light/dark themes.
- Migrates all 11 mermaid diagrams across `doc/spectral_analysis.md` (6), `doc/spectral_analysis_ssb.md` (4), and `doc/mcp/index.md` (1) to `.. d2::` directives with the SW library. The recurring "breadcrumb" workflow pattern maps `style X fill:#9fa4fc` to `class: sw-step-blue`; the container-highlight case falls back to highlighting inner steps.
- Each diagram is compiled twice (light + dark) and wrapped in the cosmic theme's existing `only-light` / `only-dark` divs. Per-directive ID nonces prevent cross-styling between structurally identical diagrams on the same page. Raw d2 output is cached to `build/doc/.d2-cache/` via atomic `tempfile + os.replace` writes, honoring the extension's `parallel_write_safe` contract.

## Test plan

- [x] Extension unit tests: `python -m pytest doc/_ext/ -v` — 5/5 passing (compile helper, SVG post-processing, ID-nonce isolation incl. `url(#…)` / `href="#…"` rewrites, on-disk cache, dual-themed render helper).
- [x] Full docs build: `cmake -DBUILD_DOC=ON .. && make doc` in a clean venv installed from `requirements_doc.txt`. Produces expected diagram counts: `spectral_analysis.html` 6/6, `spectral_analysis_ssb.html` 4/4, `mcp/index.html` 1/1 (light/dark). Cache populates with 22 entries (11 × 2 themes).
- [x] No residual mermaid references in source or built HTML.
- [x] Manual browser verification: all diagrams render with correct highlights; light/dark toggle via cosmic theme swaps SVGs cleanly; six stacked diagrams on `spectral_analysis.html` show no cross-style bleed; narrow viewport scales without horizontal scrollbars.
- [ ] CI confirms `pip install -r requirements_doc.txt` resolves `pyd2lang-native==0.1.1` from PyPI (pre-built wheel bundles the native library — no Go toolchain needed).

## Notes

- Accessibility (alt text, `<figure>`/`<figcaption>` semantics) is intentionally deferred: adding it would require introducing a new hidden-caption CSS class, which was scoped out of this change. No regression vs. the old mermaid output, which also lacked alt text.
- `requirements_doc.txt` pins `pyd2lang-native==0.1.1` (PyPI) rather than `git+main` so clean installs don't require a Go toolchain.