### PR TITLE
Install the [mcp] extra in docs CI so MCP API reference is not blank

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,7 +27,7 @@ jobs:
           sudo make install genalyzer
           sudo ldconfig
           cd ../bindings/python
-          pip install ".[cli,tools]"
+          pip install ".[cli,tools,mcp]"
           cd ../../build
           sudo rm -rf *
           sudo rm ../doc/reference_simplified.md
@@ -61,7 +61,7 @@ jobs:
           sudo make install genalyzer
           sudo ldconfig
           cd ../bindings/python
-          pip install ".[cli,tools]"
+          pip install ".[cli,tools,mcp]"
           cd ../../build
           sudo rm -rf *
           sudo rm ../doc/reference_simplified.md


### PR DESCRIPTION
## Summary

- `doc/mcp/reference.md` uses `.. automodule:: genalyzer.mcp.<submodule>` for seven submodules. Every one of those submodules re-exports from `genalyzer.mcp.server`, which does `from fastmcp import FastMCP`.
- The docs CI (`.github/workflows/doc.yml`) installs `genalyzer[cli,tools]` but **not** `[mcp]`, so `fastmcp` is absent and every one of those autodoc directives fails to import its module.
- Sphinx autodoc treats import failures as warnings (not errors) and silently emits no content for the failing module, leaving the MCP API Reference page on GitHub Pages with only section headings visible.

Fix: add `mcp` to the extras installed by both the `DocBuild` and `MasterDocDeploy` jobs — `pip install ".[cli,tools,mcp]"`.

## Test plan

- [x] Reproduced the failure locally by installing `genalyzer[cli,tools]` in a fresh venv and running `sphinx-build`; confirmed `WARNING: autodoc: failed to import 'mcp.generators'` (and six siblings), and that `mcp/reference.html` contained only section headings.
- [x] Installed `genalyzer[cli,tools,mcp]` in the same venv and ran `make Sphinx`; build emits no autodoc warnings and `mcp/reference.html` now contains 18 function signatures and 8555 chars of body content.
- [ ] After merge, the `MasterDocDeploy` job on `main` will rebuild and publish; the live API Reference at `https://analogdevicesinc.github.io/genalyzer/master/mcp/reference.html` should repopulate automatically.