### PR TITLE
bench: spectral-analysis perf spike (window asm ladder + pipeline profile)

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,2 @@
+*.o
+bh_window_bench

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,60 @@
+# Blackman-Harris Window Optimization-Ladder Benchmark
+
+Standalone spike measuring the speed ceiling of the genalyzer Blackman-Harris
+complex-FFT window on this AVX-256 (no-FMA) Xeon E5-1650, 6 cores.
+
+## Build & run
+    ./build.sh
+    ./bh_window_bench
+
+## Tiers
+- T0 baseline  — std::cos x3 per sample (copy of src/fourier_transforms.cpp:35)
+- T1 no-trig   — precomputed window via phasor recurrence, scalar apply
+- T2 avx-intr  — AVX-256 intrinsics apply
+- T3 asm-1core — hand-tuned AVX-256 assembly apply
+- T4 asm-6core — assembly apply split across 6 cores
+
+## Results
+
+```
+tier              nfft   navg   Msamples/s    speedup  max-abs-err
+T0 baseline       4096      1         16.0      1.00x     0.00e+00
+T1 no-trig        4096      1        153.1      9.59x     3.60e-14
+T2 avx-intr       4096      1        154.3      9.66x     3.60e-14
+T3 asm-1core      4096      1        155.2      9.71x     3.60e-14
+T4 asm-6core      4096      1         17.5      1.10x     3.60e-14
+
+T0 baseline       4096      8         97.0      1.00x     0.00e+00
+T1 no-trig        4096      8        487.2      5.02x     3.61e-14
+T2 avx-intr       4096      8        488.2      5.04x     3.61e-14
+T3 asm-1core      4096      8        491.3      5.07x     3.61e-14
+T4 asm-6core      4096      8        219.0      2.26x     3.61e-14
+
+T0 baseline      65536      1         18.7      1.00x     0.00e+00
+T1 no-trig       65536      1        149.3      8.00x     3.35e-14
+T2 avx-intr      65536      1        149.3      7.99x     3.35e-14
+T3 asm-1core     65536      1        149.7      8.01x     3.35e-14
+T4 asm-6core     65536      1        112.3      6.01x     3.35e-14
+
+T0 baseline      65536      8         46.4      1.00x     0.00e+00
+T1 no-trig       65536      8        315.5      6.80x     3.55e-14
+T2 avx-intr      65536      8        304.8      6.57x     3.55e-14
+T3 asm-1core     65536      8        310.8      6.70x     3.55e-14
+T4 asm-6core     65536      8        478.3     10.31x     3.55e-14
+
+T0 baseline    1048576      1         15.5      1.00x     0.00e+00
+T1 no-trig     1048576      1        122.6      7.93x     5.67e-14
+T2 avx-intr    1048576      1        122.6      7.93x     5.67e-14
+T3 asm-1core   1048576      1        122.1      7.90x     5.67e-14
+T4 asm-6core   1048576      1        139.8      9.04x     5.67e-14
+
+T0 baseline    1048576      8         46.5      1.00x     0.00e+00
+T1 no-trig     1048576      8        273.4      5.88x     5.79e-14
+T2 avx-intr    1048576      8        269.6      5.80x     5.79e-14
+T3 asm-1core   1048576      8        271.3      5.84x     5.79e-14
+T4 asm-6core   1048576      8        473.6     10.19x     5.79e-14
+```
+
+## Attribution
+
+Almost the entire single-core speedup comes from eliminating transcendentals: replacing three `std::cos` calls per sample with phasor recurrence (T0 → T1) delivers roughly 8–10x depending on nfft and navg. The AVX-256 intrinsics (T1 → T2) and hand-tuned assembly (T2 → T3) add virtually nothing beyond T1 on this hardware — both measure within noise of T1 at every configuration — which indicates the bottleneck after killing the transcendentals is memory bandwidth, not arithmetic throughput. The navg=1 vs. navg=8 contrast confirms this: at navg=1 the window-generation pass (still scalar, still memory-bound) dominates the total time and the apply-side tiers (T2, T3) cannot separate from T1 at all, while at navg=8 the single window array is reused across eight rows, shifting the apply phase toward compute-bound territory — yet even there T2 and T3 match T1 within a percent or two, showing the scalar loop is already bandwidth-saturated. The 6-core thread tier (T4) exposes the expected thread-spawn overhead at small nfft: at nfft=4096/navg=1 it measures only 1.10x vs T0 (slower than T1–T3) and at nfft=4096/navg=8 it is 2.26x vs T0 (well below the single-core T1 of 5.02x), because fresh thread creation on Linux costs ~10–30 µs each and overwhelms the tiny work quanta. At large nfft (65536 or 1048576) with navg=8 the thread overhead amortises and T4 achieves 10.3x and 10.2x respectively, approaching the theoretical 6-core memory-bandwidth ceiling relative to the scalar T0 baseline.

--- a/bench/README.md
+++ b/bench/README.md
@@ -7,6 +7,11 @@ complex-FFT window on this AVX-256 (no-FMA) Xeon E5-1650, 6 cores.
     ./build.sh
     ./bh_window_bench
 
+`build.sh` compiles with `g++ -O3 -mavx -std=c++17 -pthread` (g++ 13.3). The
+`-O3 -mavx` flags matter: the "T2/T3 add nothing over T1" finding below assumes
+the scalar tiers are already optimized and AVX is actually emitted. Numbers were
+measured on an otherwise-idle Xeon E5-1650 @ 3.20 GHz.
+
 ## Tiers
 - T0 baseline  — std::cos x3 per sample (copy of src/fourier_transforms.cpp:35)
 - T1 no-trig   — precomputed window via phasor recurrence, scalar apply

--- a/bench/bh_window_asm.S
+++ b/bench/bh_window_asm.S
@@ -1,0 +1,2 @@
+# AVX-256 apply kernel lives here (filled in Task 4). Empty stub for now.
+.section .note.GNU-stack,"",@progbits

--- a/bench/bh_window_asm.S
+++ b/bench/bh_window_asm.S
@@ -1,2 +1,30 @@
-# AVX-256 apply kernel lives here (filled in Task 4). Empty stub for now.
+    .text
+    .globl bh_apply_asm
+    .type  bh_apply_asm, @function
+# void bh_apply_asm(const double* sw, const double* I, const double* Q,
+#                   double* out, size_t nfft)   // nfft multiple of 4
+# rdi=sw  rsi=I  rdx=Q  rcx=out  r8=nfft
+bh_apply_asm:
+    xor     %rax, %rax                 # rax = sample index i
+.Lloop:
+    cmp     %r8, %rax
+    jae     .Ldone
+    vmovupd (%rdi,%rax,8), %ymm0        # sw[i..i+3]
+    vmovupd (%rsi,%rax,8), %ymm1        # I[i..i+3]
+    vmovupd (%rdx,%rax,8), %ymm2        # Q[i..i+3]
+    vmulpd  %ymm1, %ymm0, %ymm1         # ri = sw*I  (r0 r1 r2 r3)
+    vmulpd  %ymm2, %ymm0, %ymm2         # rq = sw*Q  (q0 q1 q2 q3)
+    vunpcklpd %ymm2, %ymm1, %ymm3       # r0 q0 r2 q2
+    vunpckhpd %ymm2, %ymm1, %ymm4       # r1 q1 r3 q3
+    vperm2f128 $0x20, %ymm4, %ymm3, %ymm5   # r0 q0 r1 q1
+    vperm2f128 $0x31, %ymm4, %ymm3, %ymm6   # r2 q2 r3 q3
+    lea     (%rax,%rax,1), %r9          # r9 = 2*i  (out is interleaved)
+    vmovupd %ymm5, (%rcx,%r9,8)         # out[2i .. 2i+3]
+    vmovupd %ymm6, 32(%rcx,%r9,8)       # out[2i+4 .. 2i+7]
+    add     $4, %rax
+    jmp     .Lloop
+.Ldone:
+    vzeroupper
+    ret
+    .size  bh_apply_asm, .-bh_apply_asm
 .section .note.GNU-stack,"",@progbits

--- a/bench/bh_window_bench.cpp
+++ b/bench/bh_window_bench.cpp
@@ -16,6 +16,9 @@
 
 using std::size_t;
 
+extern "C" void bh_apply_asm(const double* sw, const double* I,
+                             const double* Q, double* out, size_t nfft);
+
 // ---- Blackman-Harris constants (from src/fourier_transforms.cpp) ----
 static const double bh_kx = 1.9688861870585801;
 static const double bh_k0 = 0.35875;
@@ -171,6 +174,22 @@ void bh_window_t2(const double* i_data, const double* q_data, double* out_data,
     }
 }
 
+// T3: shared precomputed window, assembly apply kernel, single core.
+void bh_window_t3(const double* i_data, const double* q_data, double* out_data,
+                  size_t in_stride, size_t navg, size_t nfft) {
+    assert(in_stride == 1 && "T3 asm path assumes unit stride");
+    static thread_local std::vector<double> sw;
+    sw.resize(nfft);
+    gen_scaled_window(sw.data(), nfft);
+    const size_t in_row_stride = nfft * in_stride;
+    const size_t out_row_stride = nfft * 2;
+    for (size_t k = 0; k < navg; ++k) {
+        bh_apply_asm(sw.data(), i_data + k * in_row_stride,
+                     q_data + k * in_row_stride, out_data + k * out_row_stride,
+                     nfft);
+    }
+}
+
 int main() {
     const size_t in_stride = 1;
     struct Tier { const char* name; window_fn fn; };
@@ -178,6 +197,7 @@ int main() {
         {"T0 baseline", bh_window_t0},
         {"T1 no-trig ", bh_window_t1},
         {"T2 avx-intr", bh_window_t2},
+        {"T3 asm-1core", bh_window_t3},
     };
 
     // Anchor T0 against the independent reference on a small case.

--- a/bench/bh_window_bench.cpp
+++ b/bench/bh_window_bench.cpp
@@ -248,6 +248,26 @@ void bh_window_t4(const double* i_data, const double* q_data, double* out_data,
     }
 }
 
+// Best Msamples/s over repeated runs totaling >= min_sec (warm-up discarded).
+double bench_msps(window_fn fn, const double* I, const double* Q, double* out,
+                  size_t in_stride, size_t navg, size_t nfft, double min_sec) {
+    fn(I, Q, out, in_stride, navg, nfft);  // warm-up
+    using clk = std::chrono::steady_clock;
+    double best = 0.0, elapsed = 0.0;
+    auto t0 = clk::now();
+    const double samples = (double)nfft * (double)navg;
+    while (elapsed < min_sec) {
+        auto a = clk::now();
+        fn(I, Q, out, in_stride, navg, nfft);
+        auto b = clk::now();
+        double dt = std::chrono::duration<double>(b - a).count();
+        double msps = samples / dt / 1e6;
+        if (msps > best) best = msps;
+        elapsed = std::chrono::duration<double>(b - t0).count();
+    }
+    return best;
+}
+
 int main() {
     const size_t in_stride = 1;
     struct Tier { const char* name; window_fn fn; };
@@ -312,6 +332,36 @@ int main() {
                         t.name, e, e < 1e-9 ? "PASS" : "FAIL");
             if (!(e < 1e-9)) return 1;
         }
+    }
+
+    // ---- Timing sweep ----
+    struct Cfg { size_t nfft, navg; };
+    Cfg cfgs[] = {
+        {4096, 1}, {4096, 8},
+        {65536, 1}, {65536, 8},
+        {1048576, 1}, {1048576, 8},
+    };
+    std::printf("\n%-12s %9s %6s %12s %10s %12s\n",
+                "tier", "nfft", "navg", "Msamples/s", "speedup", "max-abs-err");
+    std::mt19937_64 rng(2024);
+    std::uniform_real_distribution<double> dist(-1.0, 1.0);
+    for (const Cfg& c : cfgs) {
+        std::vector<double> I(c.nfft * c.navg), Q(c.nfft * c.navg);
+        for (size_t n = 0; n < I.size(); ++n) { I[n] = dist(rng); Q[n] = dist(rng); }
+        std::vector<double> ref(c.nfft * c.navg * 2), got(c.nfft * c.navg * 2);
+        bh_window_t0(I.data(), Q.data(), ref.data(), in_stride, c.navg, c.nfft);
+        double base_msps = 0.0;
+        for (const Tier& t : tiers) {
+            std::fill(got.begin(), got.end(), 0.0);
+            t.fn(I.data(), Q.data(), got.data(), in_stride, c.navg, c.nfft);
+            double e = max_abs_err(ref.data(), got.data(), ref.size());
+            double msps = bench_msps(t.fn, I.data(), Q.data(), got.data(),
+                                     in_stride, c.navg, c.nfft, 0.5);
+            if (&t == &tiers[0]) base_msps = msps;
+            std::printf("%-12s %9zu %6zu %12.1f %9.2fx %12.2e\n",
+                        t.name, c.nfft, c.navg, msps, msps / base_msps, e);
+        }
+        std::printf("\n");
     }
     return 0;
 }

--- a/bench/bh_window_bench.cpp
+++ b/bench/bh_window_bench.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <string>
 #include <algorithm>
+#include <thread>
 #include <immintrin.h>
 #ifndef __AVX__
 #error "This benchmark requires AVX (build with -mavx)."
@@ -190,6 +191,59 @@ void bh_window_t3(const double* i_data, const double* q_data, double* out_data,
     }
 }
 
+// T4: precompute window once, then run the asm apply kernel on disjoint
+// row-chunks across NTHREADS physical cores.
+static const unsigned NTHREADS = 6;  // E5-1650 physical cores
+void bh_window_t4(const double* i_data, const double* q_data, double* out_data,
+                  size_t in_stride, size_t navg, size_t nfft) {
+    assert(in_stride == 1 && "T4 asm path assumes unit stride");
+    static thread_local std::vector<double> sw;
+    sw.resize(nfft);
+    gen_scaled_window(sw.data(), nfft);
+    const size_t in_row_stride = nfft * in_stride;
+    const size_t out_row_stride = nfft * 2;
+    // Snapshot sw.data() before spawning threads: thread_local statics are NOT
+    // captured by [&] -- each thread resolves them via its own TLS slot, so
+    // worker threads would see their own (empty) sw.  Use a plain pointer.
+    const double* sw_ptr = sw.data();
+
+    auto apply_rows = [&, sw_ptr](size_t k0, size_t k1) {
+        for (size_t k = k0; k < k1; ++k)
+            bh_apply_asm(sw_ptr, i_data + k * in_row_stride,
+                         q_data + k * in_row_stride,
+                         out_data + k * out_row_stride, nfft);
+    };
+
+    if (navg >= NTHREADS) {
+        // Partition by rows.
+        std::vector<std::thread> ts;
+        size_t per = (navg + NTHREADS - 1) / NTHREADS;
+        for (unsigned t = 0; t < NTHREADS; ++t) {
+            size_t k0 = t * per, k1 = std::min(navg, k0 + per);
+            if (k0 >= k1) break;
+            ts.emplace_back(apply_rows, k0, k1);
+        }
+        for (auto& th : ts) th.join();
+    } else {
+        // Few rows: partition the single/large row's sample range instead.
+        std::vector<std::thread> ts;
+        size_t chunk = ((nfft / NTHREADS) / 4) * 4;  // keep multiple of 4
+        if (chunk == 0) chunk = nfft;
+        for (size_t k = 0; k < navg; ++k) {
+            for (size_t i0 = 0; i0 < nfft; i0 += chunk) {
+                size_t n = std::min(chunk, nfft - i0);
+                const double* pi = i_data + k * in_row_stride + i0 * in_stride;
+                const double* pq = q_data + k * in_row_stride + i0 * in_stride;
+                double* po = out_data + k * out_row_stride + 2 * i0;
+                const double* swp = sw.data() + i0;
+                ts.emplace_back([=] { bh_apply_asm(swp, pi, pq, po, n); });
+                if (ts.size() == NTHREADS) { for (auto& th : ts) th.join(); ts.clear(); }
+            }
+        }
+        for (auto& th : ts) th.join();
+    }
+}
+
 int main() {
     const size_t in_stride = 1;
     struct Tier { const char* name; window_fn fn; };
@@ -198,6 +252,7 @@ int main() {
         {"T1 no-trig ", bh_window_t1},
         {"T2 avx-intr", bh_window_t2},
         {"T3 asm-1core", bh_window_t3},
+        {"T4 asm-6core", bh_window_t4},
     };
 
     // Anchor T0 against the independent reference on a small case.

--- a/bench/bh_window_bench.cpp
+++ b/bench/bh_window_bench.cpp
@@ -1,5 +1,6 @@
 // Standalone benchmark for the genalyzer Blackman-Harris complex-FFT window.
 // Build: ./build.sh   Run: ./bh_window_bench
+#include <cassert>
 #include <cstddef>
 #include <cstdio>
 #include <cmath>
@@ -9,6 +10,9 @@
 #include <string>
 #include <algorithm>
 #include <immintrin.h>
+#ifndef __AVX__
+#error "This benchmark requires AVX (build with -mavx)."
+#endif
 
 using std::size_t;
 
@@ -141,6 +145,7 @@ void bh_window_t1(const double* i_data, const double* q_data, double* out_data,
 // out = r0,q0,r1,q1,r2,q2,r3,q3. nfft assumed multiple of 4.
 void bh_window_t2(const double* i_data, const double* q_data, double* out_data,
                   size_t in_stride, size_t navg, size_t nfft) {
+    assert(in_stride == 1 && "T2 AVX path assumes unit stride");
     static thread_local std::vector<double> sw;
     sw.resize(nfft);
     gen_scaled_window(sw.data(), nfft);

--- a/bench/bh_window_bench.cpp
+++ b/bench/bh_window_bench.cpp
@@ -7,6 +7,7 @@
 #include <random>
 #include <chrono>
 #include <string>
+#include <algorithm>
 
 using std::size_t;
 
@@ -89,18 +90,89 @@ double max_abs_err(const double* a, const double* b, size_t n) {
     return m;
 }
 
+// Generate sw[i] = bh_kx * window(i), i = 0..nfft-1, with NO per-sample
+// transcendentals: advance three complex phasors (for the 1st/2nd/3rd harmonic)
+// and renormalize every 1024 samples to bound floating-point drift.
+void gen_scaled_window(double* sw, size_t nfft) {
+    const double th = k_2pi / (double)nfft;
+    const double cz1 = std::cos(th),     sz1 = std::sin(th);
+    const double cz2 = std::cos(2 * th), sz2 = std::sin(2 * th);
+    const double cz3 = std::cos(3 * th), sz3 = std::sin(3 * th);
+    double c1 = 1, s1 = 0, c2 = 1, s2 = 0, c3 = 1, s3 = 0;
+    for (size_t i = 0; i < nfft; ++i) {
+        sw[i] = bh_kx * (bh_k0 + bh_k1 * c1 + bh_k2 * c2 + bh_k3 * c3);
+        double nc1 = c1 * cz1 - s1 * sz1, ns1 = c1 * sz1 + s1 * cz1; c1 = nc1; s1 = ns1;
+        double nc2 = c2 * cz2 - s2 * sz2, ns2 = c2 * sz2 + s2 * cz2; c2 = nc2; s2 = ns2;
+        double nc3 = c3 * cz3 - s3 * sz3, ns3 = c3 * sz3 + s3 * cz3; c3 = nc3; s3 = ns3;
+        if (((i + 1) & 1023) == 0) {
+            double x = (double)(i + 1);
+            c1 = std::cos(th * x);     s1 = std::sin(th * x);
+            c2 = std::cos(2 * th * x); s2 = std::sin(2 * th * x);
+            c3 = std::cos(3 * th * x); s3 = std::sin(3 * th * x);
+        }
+    }
+}
+
+// T1: precompute scaled window once, then scalar apply across all navg rows.
+void bh_window_t1(const double* i_data, const double* q_data, double* out_data,
+                  size_t in_stride, size_t navg, size_t nfft) {
+    static thread_local std::vector<double> sw;
+    sw.resize(nfft);
+    gen_scaled_window(sw.data(), nfft);
+    const size_t in_row_stride = nfft * in_stride;
+    const size_t out_row_stride = nfft * 2;
+    for (size_t k = 0; k < navg; ++k) {
+        const double* pi = i_data + k * in_row_stride;
+        const double* pq = q_data + k * in_row_stride;
+        double* po = out_data + k * out_row_stride;
+        for (size_t i = 0; i < nfft; ++i) {
+            po[2 * i] = sw[i] * pi[i * in_stride];
+            po[2 * i + 1] = sw[i] * pq[i * in_stride];
+        }
+    }
+}
+
 int main() {
-    // Tiny anchored self-test: T0 vs the independent reference.
-    const size_t nfft = 16, navg = 2, in_stride = 1;
-    std::mt19937_64 rng(12345);
-    std::uniform_real_distribution<double> dist(-1.0, 1.0);
-    std::vector<double> I(nfft * navg), Q(nfft * navg);
-    for (size_t n = 0; n < I.size(); ++n) { I[n] = dist(rng); Q[n] = dist(rng); }
-    std::vector<double> out0(nfft * navg * 2), outr(nfft * navg * 2);
-    bh_window_t0(I.data(), Q.data(), out0.data(), in_stride, navg, nfft);
-    bh_window_ref(I.data(), Q.data(), outr.data(), in_stride, navg, nfft);
-    double err = max_abs_err(out0.data(), outr.data(), out0.size());
-    std::printf("T0 anchor max-abs-err = %.3e -> %s\n", err,
-                err < 1e-12 ? "PASS" : "FAIL");
-    return err < 1e-12 ? 0 : 1;
+    const size_t in_stride = 1;
+    struct Tier { const char* name; window_fn fn; };
+    Tier tiers[] = {
+        {"T0 baseline", bh_window_t0},
+        {"T1 no-trig ", bh_window_t1},
+    };
+
+    // Anchor T0 against the independent reference on a small case.
+    {
+        const size_t nfft = 16, navg = 2;
+        std::mt19937_64 rng(12345);
+        std::uniform_real_distribution<double> dist(-1.0, 1.0);
+        std::vector<double> I(nfft * navg), Q(nfft * navg);
+        for (size_t n = 0; n < I.size(); ++n) { I[n] = dist(rng); Q[n] = dist(rng); }
+        std::vector<double> a(nfft * navg * 2), b(nfft * navg * 2);
+        bh_window_t0(I.data(), Q.data(), a.data(), in_stride, navg, nfft);
+        bh_window_ref(I.data(), Q.data(), b.data(), in_stride, navg, nfft);
+        double e = max_abs_err(a.data(), b.data(), a.size());
+        std::printf("anchor: T0 vs ref max-abs-err = %.3e -> %s\n", e,
+                    e < 1e-12 ? "PASS" : "FAIL");
+        if (!(e < 1e-12)) return 1;
+    }
+
+    // Correctness: every tier vs T0 on a representative case.
+    {
+        const size_t nfft = 65536, navg = 8;
+        std::mt19937_64 rng(777);
+        std::uniform_real_distribution<double> dist(-1.0, 1.0);
+        std::vector<double> I(nfft * navg), Q(nfft * navg);
+        for (size_t n = 0; n < I.size(); ++n) { I[n] = dist(rng); Q[n] = dist(rng); }
+        std::vector<double> ref(nfft * navg * 2), got(nfft * navg * 2);
+        bh_window_t0(I.data(), Q.data(), ref.data(), in_stride, navg, nfft);
+        for (const Tier& t : tiers) {
+            std::fill(got.begin(), got.end(), 0.0);
+            t.fn(I.data(), Q.data(), got.data(), in_stride, navg, nfft);
+            double e = max_abs_err(ref.data(), got.data(), ref.size());
+            std::printf("correctness: %s max-abs-err = %.3e -> %s\n",
+                        t.name, e, e < 1e-9 ? "PASS" : "FAIL");
+            if (!(e < 1e-9)) return 1;
+        }
+    }
+    return 0;
 }

--- a/bench/bh_window_bench.cpp
+++ b/bench/bh_window_bench.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <string>
 #include <algorithm>
+#include <immintrin.h>
 
 using std::size_t;
 
@@ -135,12 +136,43 @@ void bh_window_t1(const double* i_data, const double* q_data, double* out_data,
     }
 }
 
+// T2: shared precomputed window, AVX-256 apply. Processes 4 samples/iter.
+// For samples i..i+3: ri = sw*I, rq = sw*Q, then interleave to
+// out = r0,q0,r1,q1,r2,q2,r3,q3. nfft assumed multiple of 4.
+void bh_window_t2(const double* i_data, const double* q_data, double* out_data,
+                  size_t in_stride, size_t navg, size_t nfft) {
+    static thread_local std::vector<double> sw;
+    sw.resize(nfft);
+    gen_scaled_window(sw.data(), nfft);
+    const size_t in_row_stride = nfft * in_stride;  // in_stride==1 in workload
+    const size_t out_row_stride = nfft * 2;
+    for (size_t k = 0; k < navg; ++k) {
+        const double* pi = i_data + k * in_row_stride;
+        const double* pq = q_data + k * in_row_stride;
+        double* po = out_data + k * out_row_stride;
+        for (size_t i = 0; i < nfft; i += 4) {
+            __m256d w  = _mm256_loadu_pd(sw.data() + i);
+            __m256d vi = _mm256_loadu_pd(pi + i);
+            __m256d vq = _mm256_loadu_pd(pq + i);
+            __m256d ri = _mm256_mul_pd(w, vi);   // r0 r1 r2 r3
+            __m256d rq = _mm256_mul_pd(w, vq);   // q0 q1 q2 q3
+            __m256d lo = _mm256_unpacklo_pd(ri, rq);  // r0 q0 r2 q2
+            __m256d hi = _mm256_unpackhi_pd(ri, rq);  // r1 q1 r3 q3
+            __m256d o0 = _mm256_permute2f128_pd(lo, hi, 0x20); // r0 q0 r1 q1
+            __m256d o1 = _mm256_permute2f128_pd(lo, hi, 0x31); // r2 q2 r3 q3
+            _mm256_storeu_pd(po + 2 * i, o0);
+            _mm256_storeu_pd(po + 2 * i + 4, o1);
+        }
+    }
+}
+
 int main() {
     const size_t in_stride = 1;
     struct Tier { const char* name; window_fn fn; };
     Tier tiers[] = {
         {"T0 baseline", bh_window_t0},
         {"T1 no-trig ", bh_window_t1},
+        {"T2 avx-intr", bh_window_t2},
     };
 
     // Anchor T0 against the independent reference on a small case.

--- a/bench/bh_window_bench.cpp
+++ b/bench/bh_window_bench.cpp
@@ -116,6 +116,9 @@ void gen_scaled_window(double* sw, size_t nfft) {
 // T1: precompute scaled window once, then scalar apply across all navg rows.
 void bh_window_t1(const double* i_data, const double* q_data, double* out_data,
                   size_t in_stride, size_t navg, size_t nfft) {
+    // Scratch buffer reused only to avoid reallocation; the window is
+    // regenerated every call by design (we measure per-call generate+apply
+    // cost, as the library does). NOT a cross-call cache.
     static thread_local std::vector<double> sw;
     sw.resize(nfft);
     gen_scaled_window(sw.data(), nfft);
@@ -170,6 +173,26 @@ int main() {
             t.fn(I.data(), Q.data(), got.data(), in_stride, navg, nfft);
             double e = max_abs_err(ref.data(), got.data(), ref.size());
             std::printf("correctness: %s max-abs-err = %.3e -> %s\n",
+                        t.name, e, e < 1e-9 ? "PASS" : "FAIL");
+            if (!(e < 1e-9)) return 1;
+        }
+    }
+
+    // Correctness (renorm coverage): nfft not a multiple of 1024 exercises the
+    // phasor renormalization branch and its partial tail.
+    {
+        const size_t nfft = 3000, navg = 1;
+        std::mt19937_64 rng(99);
+        std::uniform_real_distribution<double> dist(-1.0, 1.0);
+        std::vector<double> I(nfft * navg), Q(nfft * navg);
+        for (size_t n = 0; n < I.size(); ++n) { I[n] = dist(rng); Q[n] = dist(rng); }
+        std::vector<double> ref(nfft * navg * 2), got(nfft * navg * 2);
+        bh_window_t0(I.data(), Q.data(), ref.data(), in_stride, navg, nfft);
+        for (const Tier& t : tiers) {
+            std::fill(got.begin(), got.end(), 0.0);
+            t.fn(I.data(), Q.data(), got.data(), in_stride, navg, nfft);
+            double e = max_abs_err(ref.data(), got.data(), ref.size());
+            std::printf("renorm-cov:  %s max-abs-err = %.3e -> %s\n",
                         t.name, e, e < 1e-9 ? "PASS" : "FAIL");
             if (!(e < 1e-9)) return 1;
         }

--- a/bench/bh_window_bench.cpp
+++ b/bench/bh_window_bench.cpp
@@ -193,6 +193,10 @@ void bh_window_t3(const double* i_data, const double* q_data, double* out_data,
 
 // T4: precompute window once, then run the asm apply kernel on disjoint
 // row-chunks across NTHREADS physical cores.
+// NOTE: T4 spawns fresh std::threads per call (no thread pool). Thread creation
+// is ~10-30us each on Linux, so for small nfft (e.g. 4096) with navg=1 the
+// spawn overhead can exceed the actual apply work and make T4 measure SLOWER
+// than the single-core T3. The multicore win shows up at large nfft / large navg.
 static const unsigned NTHREADS = 6;  // E5-1650 physical cores
 void bh_window_t4(const double* i_data, const double* q_data, double* out_data,
                   size_t in_stride, size_t navg, size_t nfft) {
@@ -235,9 +239,9 @@ void bh_window_t4(const double* i_data, const double* q_data, double* out_data,
                 const double* pi = i_data + k * in_row_stride + i0 * in_stride;
                 const double* pq = q_data + k * in_row_stride + i0 * in_stride;
                 double* po = out_data + k * out_row_stride + 2 * i0;
-                const double* swp = sw.data() + i0;
+                const double* swp = sw_ptr + i0;
                 ts.emplace_back([=] { bh_apply_asm(swp, pi, pq, po, n); });
-                if (ts.size() == NTHREADS) { for (auto& th : ts) th.join(); ts.clear(); }
+                if (ts.size() == (size_t)NTHREADS) { for (auto& th : ts) th.join(); ts.clear(); }
             }
         }
         for (auto& th : ts) th.join();

--- a/bench/bh_window_bench.cpp
+++ b/bench/bh_window_bench.cpp
@@ -1,0 +1,106 @@
+// Standalone benchmark for the genalyzer Blackman-Harris complex-FFT window.
+// Build: ./build.sh   Run: ./bh_window_bench
+#include <cstddef>
+#include <cstdio>
+#include <cmath>
+#include <vector>
+#include <random>
+#include <chrono>
+#include <string>
+
+using std::size_t;
+
+// ---- Blackman-Harris constants (from src/fourier_transforms.cpp) ----
+static const double bh_kx = 1.9688861870585801;
+static const double bh_k0 = 0.35875;
+static const double bh_k1 = -0.48829;
+static const double bh_k2 = 0.14128;
+static const double bh_k3 = -0.01168;
+static const double k_2pi = 6.283185307179586476925286766559;
+
+using window_fn = void (*)(const double*, const double*, double*,
+                           size_t, size_t, size_t);
+
+// ---- T0: baseline, faithful to src/fourier_transforms.cpp:35 ----
+// (navg>=2 branches in the original are an unrolled but behaviorally identical
+// path; collapsed here into one general loop.)
+void bh_window_t0(const double* i_data, const double* q_data, double* out_data,
+                  size_t in_stride, size_t navg, size_t nfft) {
+    const double scalar = bh_kx;
+    const double k1 = k_2pi / (double)nfft;
+    const double k2 = k1 * 2;
+    const double k3 = k1 * 3;
+    const size_t in_row_stride = nfft * in_stride;
+    const size_t out_row_stride = nfft * 2;
+    size_t i = 0;
+    double x = 0.0;
+    if (1 == navg) {
+        for (size_t j = 0; j < out_row_stride; j += 2) {
+            const double w = bh_k0 + bh_k1 * std::cos(k1 * x) +
+                             bh_k2 * std::cos(k2 * x) + bh_k3 * std::cos(k3 * x);
+            out_data[j] = w * scalar * i_data[i];
+            out_data[j + 1] = w * scalar * q_data[i];
+            i += in_stride;
+            x += 1.0;
+        }
+    } else {
+        for (size_t j = 0; j < out_row_stride; j += 2) {
+            const double w = bh_k0 + bh_k1 * std::cos(k1 * x) +
+                             bh_k2 * std::cos(k2 * x) + bh_k3 * std::cos(k3 * x);
+            const double* pi = i_data;
+            const double* pq = q_data;
+            double* po = out_data;
+            for (size_t k = 0; k < navg; ++k) {
+                po[j] = w * scalar * pi[i];
+                po[j + 1] = w * scalar * pq[i];
+                pi += in_row_stride;
+                pq += in_row_stride;
+                po += out_row_stride;
+            }
+            i += in_stride;
+            x += 1.0;
+        }
+    }
+}
+
+// ---- Independent reference (different arrangement) to anchor T0 ----
+void bh_window_ref(const double* i_data, const double* q_data, double* out,
+                   size_t in_stride, size_t navg, size_t nfft) {
+    for (size_t k = 0; k < navg; ++k) {
+        for (size_t i = 0; i < nfft; ++i) {
+            const double x = (double)i;
+            const double w = bh_k0 + bh_k1 * std::cos(k_2pi * 1.0 * x / nfft) +
+                             bh_k2 * std::cos(k_2pi * 2.0 * x / nfft) +
+                             bh_k3 * std::cos(k_2pi * 3.0 * x / nfft);
+            const double si = i_data[k * nfft * in_stride + i * in_stride];
+            const double sq = q_data[k * nfft * in_stride + i * in_stride];
+            out[k * nfft * 2 + 2 * i] = w * bh_kx * si;
+            out[k * nfft * 2 + 2 * i + 1] = w * bh_kx * sq;
+        }
+    }
+}
+
+double max_abs_err(const double* a, const double* b, size_t n) {
+    double m = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+        double d = std::fabs(a[i] - b[i]);
+        if (d > m) m = d;
+    }
+    return m;
+}
+
+int main() {
+    // Tiny anchored self-test: T0 vs the independent reference.
+    const size_t nfft = 16, navg = 2, in_stride = 1;
+    std::mt19937_64 rng(12345);
+    std::uniform_real_distribution<double> dist(-1.0, 1.0);
+    std::vector<double> I(nfft * navg), Q(nfft * navg);
+    for (size_t n = 0; n < I.size(); ++n) { I[n] = dist(rng); Q[n] = dist(rng); }
+    std::vector<double> out0(nfft * navg * 2), outr(nfft * navg * 2);
+    bh_window_t0(I.data(), Q.data(), out0.data(), in_stride, navg, nfft);
+    bh_window_ref(I.data(), Q.data(), outr.data(), in_stride, navg, nfft);
+    double err = max_abs_err(out0.data(), outr.data(), out0.size());
+    std::printf("T0 anchor max-abs-err = %.3e -> %s\n", err,
+                err < 1e-12 ? "PASS" : "FAIL");
+    return err < 1e-12 ? 0 : 1;
+}

--- a/bench/build.sh
+++ b/bench/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+# Ensure the real system assembler (/usr/bin/as) is found before any user-local
+# wrapper that might shadow it (e.g. ~/.local/bin/as used as an agent launcher).
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin${PATH:+:$PATH}"
+g++ -O3 -mavx -std=c++17 -pthread -c bh_window_bench.cpp -o bh_window_bench.o
+g++ -c bh_window_asm.S -o bh_window_asm.o
+g++ bh_window_bench.o bh_window_asm.o -o bh_window_bench -pthread
+echo "built ./bench/bh_window_bench"

--- a/bench/profile/.gitignore
+++ b/bench/profile/.gitignore
@@ -1,0 +1,2 @@
+profile_pipeline
+*.o

--- a/bench/profile/PROFILE.md
+++ b/bench/profile/PROFILE.md
@@ -1,0 +1,68 @@
+# Real-pipeline profile: where does genalyzer's complex FFT spend its time?
+
+Goal: before optimizing `reduce_and_scale` (the per-bin `std::arg`/atan2 +
+`std::polar`/sincos stage), confirm on the REAL pipeline that it actually
+dominates — measure, don't assume.
+
+## Method
+
+`perf` is unavailable here (`perf_event_paranoid=4`, no CAP_PERFMON, can't sudo),
+so instead of sampling, the three stages inside the real `genalyzer_impl::fft()`
+complex/real_t path were temporarily wrapped with `std::chrono::steady_clock`
+accumulators (window apply / FFTW execute / reduce_and_scale), printed at exit.
+That instrumentation was reverted after measuring — it is NOT committed to
+`src/`. `profile_pipeline.cpp` (this dir) drives the real `fft()` on a
+representative complex tone + noise, one (nfft, navg) per process so the at-exit
+breakdown is cleanly attributed.
+
+Build/run (library built Release `-O3 -march=native`):
+
+    # build lib with stage timers, then:
+    g++ -O3 -std=c++17 -Iinclude bench/profile/profile_pipeline.cpp \
+        -o bench/profile/profile_pipeline \
+        -Lbuild/bindings/c/src -lgenalyzer -Wl,-rpath,$PWD/build/bindings/c/src
+    LD_LIBRARY_PATH=build/bindings/c/src \
+        GEN_PROFILE=1 bench/profile/profile_pipeline <nfft> <navg> 1.0
+
+Machine: Xeon E5-1650 @ 3.20 GHz, AVX-256 no-FMA. Measured 2026-06-19.
+
+## Result — `reduce_and_scale` dominates, and is bigger than the FFT itself
+
+Stage share of total `fft()` wall time:
+
+| nfft    | navg | window | FFTW  | reduce_and_scale | reduce vs FFTW |
+|---------|------|--------|-------|------------------|----------------|
+| 4096    | 8    | 16.6%  | 14.9% | **68.5%**        | 4.6x           |
+| 65536   | 8    | 23.2%  | 19.0% | **57.8%**        | 3.0x           |
+| 1048576 | 8    | 21.6%  | 31.4% | **47.0%**        | 1.5x           |
+| 65536   | 1    | 82.8%  | 17.2% | 0% (scale only)  | —              |
+| 1048576 | 1    | 76.5%  | 35.5% | 0% (scale only)  | —              |
+
+Raw per-config stage totals (summed over the timed iterations):
+
+    nfft=4096    navg=8  window=0.1656s fftw=0.1487s reduce=0.6838s (461 calls)
+    nfft=65536   navg=8  window=0.2421s fftw=0.1984s reduce=0.6026s (25 calls)
+    nfft=1048576 navg=8  window=0.5359s fftw=0.7793s reduce=1.1642s (3 calls)
+    nfft=65536   navg=1  window=0.8294s fftw=0.1722s reduce=0.0000s (168 calls)
+    nfft=1048576 navg=1  window=0.7653s fftw=0.3555s reduce=0.0000s (11 calls)
+
+## Conclusions
+
+1. **`reduce_and_scale` is the single largest stage whenever navg > 1** — 47-68%
+   of the whole transform, i.e. 1.5x-4.6x the cost of the FFT itself. It is only
+   present for averaging (navg > 1); navg == 1 uses the cheap `scale_fft` and the
+   window becomes the top cost (the stage the earlier window spike attacked).
+2. The cost is `std::arg` (atan2) computed `navg * nfft` times plus `std::polar`
+   (sincos) `nfft` times — data-dependent transcendentals that, unlike the
+   window's, cannot be precomputed away. So this is a genuine compute-bound
+   transcendental target where SIMD/asm (vectorized atan2/sincos) would pay off.
+3. **Bigger lever first (algorithmic):** the analysis path consumes mean-square
+   magnitude (`analyze_impl(const real_t *msq_data ...)`, "phase not available")
+   and only pulls phase on-demand at a handful of tone bins via `fa_phase` ->
+   `std::arg(fft_data[index])`. So the `navg * nfft` atan2 calls that retain
+   phase for every bin look largely wasted. Eliminating/deferring per-bin phase
+   would likely beat any SIMD on atan2.
+
+Next step options: (a) extend the optimization-ladder spike to `reduce_and_scale`
+(T0 baseline -> drop-phase algorithmic -> vectorized atan2/sincos -> asm ->
+multicore); (b) trace whether per-bin phase can be safely deferred to tone bins.

--- a/bench/profile/profile_pipeline.cpp
+++ b/bench/profile/profile_pipeline.cpp
@@ -1,0 +1,62 @@
+// Profiling driver for the REAL genalyzer fft() pipeline.
+// Calls genalyzer_impl::fft (complex, real_t path: window -> FFTW ->
+// reduce_and_scale) on a representative complex tone, timing the whole
+// transform. The library is built with TEMP stage-instrumentation that prints
+// per-stage wall-clock at process exit when env GEN_PROFILE is set.
+//
+// Run ONE config per process so the at-exit stage breakdown is attributed to
+// exactly that (nfft, navg).
+//
+//   usage: profile_pipeline <nfft> <navg> [seconds]
+#include "enums.hpp"
+#include "fourier_transforms.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+#include <vector>
+
+using namespace genalyzer_impl;
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: %s <nfft> <navg> [seconds]\n", argv[0]);
+        return 2;
+    }
+    const size_t nfft = std::strtoull(argv[1], nullptr, 10);
+    const size_t navg = std::strtoull(argv[2], nullptr, 10);
+    const double min_sec = (argc > 3) ? std::strtod(argv[3], nullptr) : 1.0;
+
+    const size_t isize = nfft * navg;
+    std::vector<double> I(isize), Q(isize), out(nfft * 2);
+    std::mt19937_64 rng(7);
+    std::uniform_real_distribution<double> noise(-1e-2, 1e-2);
+    const double f = 0.123; // a tone, normalized freq
+    for (size_t n = 0; n < isize; ++n) {
+        I[n] = std::cos(2 * M_PI * f * (double)n) + noise(rng);
+        Q[n] = std::sin(2 * M_PI * f * (double)n) + noise(rng);
+    }
+
+    using clk = std::chrono::steady_clock;
+    // warm-up (also builds FFTW plan, primes caches) -- not timed
+    fft(I.data(), isize, Q.data(), isize, out.data(), nfft * 2, navg, nfft,
+        Window::BlackmanHarris);
+
+    long iters = 0;
+    double elapsed = 0.0;
+    auto t0 = clk::now();
+    while (elapsed < min_sec) {
+        fft(I.data(), isize, Q.data(), isize, out.data(), nfft * 2, navg, nfft,
+            Window::BlackmanHarris);
+        ++iters;
+        elapsed = std::chrono::duration<double>(clk::now() - t0).count();
+    }
+    const double per_ms = elapsed / iters * 1e3;
+    const double msps = (double)nfft * navg / (elapsed / iters) / 1e6;
+    std::printf("nfft=%zu navg=%zu  iters=%ld  per_call=%.4f ms  %.1f Msamp/s\n",
+                nfft, navg, iters, per_ms, msps);
+    // The TEMP stage-profile line prints to stderr at exit (GEN_PROFILE set).
+    return 0;
+}

--- a/bench/results.txt
+++ b/bench/results.txt
@@ -1,3 +1,4 @@
+# Generated 2026-06-19 on Xeon E5-1650 @ 3.20GHz (AVX-256, no FMA), g++ 13.3, build.sh flags: -O3 -mavx -std=c++17 -pthread
 anchor: T0 vs ref max-abs-err = 0.000e+00 -> PASS
 correctness: T0 baseline max-abs-err = 0.000e+00 -> PASS
 correctness: T1 no-trig  max-abs-err = 3.531e-14 -> PASS

--- a/bench/results.txt
+++ b/bench/results.txt
@@ -1,0 +1,49 @@
+anchor: T0 vs ref max-abs-err = 0.000e+00 -> PASS
+correctness: T0 baseline max-abs-err = 0.000e+00 -> PASS
+correctness: T1 no-trig  max-abs-err = 3.531e-14 -> PASS
+correctness: T2 avx-intr max-abs-err = 3.531e-14 -> PASS
+correctness: T3 asm-1core max-abs-err = 3.531e-14 -> PASS
+correctness: T4 asm-6core max-abs-err = 3.531e-14 -> PASS
+renorm-cov:  T0 baseline max-abs-err = 0.000e+00 -> PASS
+renorm-cov:  T1 no-trig  max-abs-err = 5.604e-14 -> PASS
+renorm-cov:  T2 avx-intr max-abs-err = 5.604e-14 -> PASS
+renorm-cov:  T3 asm-1core max-abs-err = 5.604e-14 -> PASS
+renorm-cov:  T4 asm-6core max-abs-err = 5.604e-14 -> PASS
+
+tier              nfft   navg   Msamples/s    speedup  max-abs-err
+T0 baseline       4096      1         16.0      1.00x     0.00e+00
+T1 no-trig        4096      1        153.1      9.59x     3.60e-14
+T2 avx-intr       4096      1        154.3      9.66x     3.60e-14
+T3 asm-1core      4096      1        155.2      9.71x     3.60e-14
+T4 asm-6core      4096      1         17.5      1.10x     3.60e-14
+
+T0 baseline       4096      8         97.0      1.00x     0.00e+00
+T1 no-trig        4096      8        487.2      5.02x     3.61e-14
+T2 avx-intr       4096      8        488.2      5.04x     3.61e-14
+T3 asm-1core      4096      8        491.3      5.07x     3.61e-14
+T4 asm-6core      4096      8        219.0      2.26x     3.61e-14
+
+T0 baseline      65536      1         18.7      1.00x     0.00e+00
+T1 no-trig       65536      1        149.3      8.00x     3.35e-14
+T2 avx-intr      65536      1        149.3      7.99x     3.35e-14
+T3 asm-1core     65536      1        149.7      8.01x     3.35e-14
+T4 asm-6core     65536      1        112.3      6.01x     3.35e-14
+
+T0 baseline      65536      8         46.4      1.00x     0.00e+00
+T1 no-trig       65536      8        315.5      6.80x     3.55e-14
+T2 avx-intr      65536      8        304.8      6.57x     3.55e-14
+T3 asm-1core     65536      8        310.8      6.70x     3.55e-14
+T4 asm-6core     65536      8        478.3     10.31x     3.55e-14
+
+T0 baseline    1048576      1         15.5      1.00x     0.00e+00
+T1 no-trig     1048576      1        122.6      7.93x     5.67e-14
+T2 avx-intr    1048576      1        122.6      7.93x     5.67e-14
+T3 asm-1core   1048576      1        122.1      7.90x     5.67e-14
+T4 asm-6core   1048576      1        139.8      9.04x     5.67e-14
+
+T0 baseline    1048576      8         46.5      1.00x     0.00e+00
+T1 no-trig     1048576      8        273.4      5.88x     5.79e-14
+T2 avx-intr    1048576      8        269.6      5.80x     5.79e-14
+T3 asm-1core   1048576      8        271.3      5.84x     5.79e-14
+T4 asm-6core   1048576      8        473.6     10.19x     5.79e-14
+

--- a/docs/superpowers/2026-06-22-spectral-perf-session-state.md
+++ b/docs/superpowers/2026-06-22-spectral-perf-session-state.md
@@ -1,0 +1,119 @@
+# Session state — genalyzer spectral-analysis performance exploration
+
+**Purpose:** hand-off so a fresh session can resume cold after a reboot.
+**Last updated:** 2026-06-22. **Branch:** `bench/bh-window-asm` (off `main`).
+
+---
+
+## Goal
+
+Explore how fast genalyzer's spectral-analysis math can go, down to hand-tuned
+assembly — a research spike (throwaway, non-portable OK), not a production
+refactor. Nothing in `src/` is modified; all work lives under `bench/`.
+
+## Hardware / environment quirks (IMPORTANT for any rebuild)
+
+- CPU: Intel Xeon E5-1650 (Sandy Bridge-E). **AVX-256, NO FMA, NO AVX2, NO
+  AVX-512.** 6 physical cores / 12 threads. `real_t = double`.
+- **Shadowed assembler:** `~/.local/bin/as` is an "agent session launcher" that
+  hijacks the real `/usr/bin/as`, breaking g++/CMake assembly. Workaround used
+  everywhere: prepend system paths first —
+  `export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH`
+  (`bench/build.sh` already does this).
+- **perf is blocked:** `perf_event_paranoid=4`, no CAP_PERFMON, no sudo. perf
+  sampling unavailable — profiling was done via temporary in-source stage timers
+  (since reverted). If a reboot lowers paranoid, perf becomes an option.
+- FFTW3 + headers installed; CMake + g++ 13.3 present.
+
+## Work completed
+
+### 1. Window optimization-ladder spike (DONE, all reviewed)
+- Spec: `docs/superpowers/specs/2026-06-19-blackman-harris-window-asm-design.md`
+- Plan: `docs/superpowers/plans/2026-06-19-blackman-harris-window-asm-benchmark.md`
+- Code: `bench/bh_window_bench.cpp`, `bench/bh_window_asm.S`, `bench/build.sh`,
+  `bench/README.md`, `bench/results.txt`. Build+run: `bench/build.sh &&
+  bench/bh_window_bench`.
+- Tiers T0 baseline (std::cos x3/sample) -> T1 no-transcendentals (phasor
+  recurrence) -> T2 AVX-256 intrinsics -> T3 hand-tuned asm -> T4 multithreaded.
+- **Finding:** ~8-10x single-core gain came ENTIRELY from T0->T1 (killing the
+  transcendentals + precomputing the data-independent window). T2/T3 (SIMD/asm)
+  added ~nothing — once transcendentals are gone the apply loop is
+  memory-bandwidth-bound. T4 only wins at large nfft+navg (~10x), slower than T3
+  at small nfft (thread-spawn overhead). Lesson: **the window's transcendentals
+  are data-independent, so the win is algorithmic, not asm.**
+
+### 2. Real-pipeline profile (DONE)
+- `bench/profile/PROFILE.md` (full method + numbers), `profile_pipeline.cpp`.
+- Method: temporary `std::chrono` stage timers inside the real
+  `genalyzer_impl::fft()` (window / FFTW / reduce_and_scale), env-gated print at
+  exit, **reverted after measuring (not committed to src/)**. Driver calls the
+  real `fft()` on a complex tone, one (nfft,navg) per process.
+- **Finding (confirmed hypothesis):** `reduce_and_scale` is the SINGLE LARGEST
+  stage whenever navg>1 — **47-68% of the whole transform, 1.5-4.6x the FFT
+  itself.** It is `std::arg` (atan2) called `navg*nfft` times + `std::polar`
+  (sincos) `nfft` times. navg==1 uses cheap `scale_fft` (no atan2) and the
+  window dominates there instead.
+
+  | nfft | navg | window | FFTW | reduce_and_scale |
+  |------|------|--------|------|------------------|
+  | 4096 | 8 | 16.6% | 14.9% | 68.5% |
+  | 65536 | 8 | 23.2% | 19.0% | 57.8% |
+  | 1048576 | 8 | 21.6% | 31.4% | 47.0% |
+
+## Key insight / the next lever
+
+`reduce_and_scale_fft`/`_rfft` live in `src/fourier_transforms.cpp` (~lines
+635-689). They store `(std::norm, std::arg)` per bin, accumulate over navg, then
+`std::polar(sqrt(...), phase)`.
+
+The analysis path consumes **mean-square magnitude only**
+(`analyze_impl(const real_t *msq_data ...)` in `src/fourier_analysis.cpp:~400`;
+comment at ~line 219: "phase not available"). Phase is pulled ON-DEMAND at a
+handful of tone bins via `fa_phase` -> `std::arg(fft_data[index])`
+(`fourier_analysis.cpp:~1149`). So the `navg*nfft` per-bin atan2 calls that
+retain phase for EVERY bin look largely wasted.
+
+**Unlike the window, these transcendentals are data-dependent (can't precompute)
+-> genuine compute-bound SIMD/asm target. But the bigger win is likely
+algorithmic: drop/defer per-bin phase.**
+
+## Planned next steps (decided, not yet started)
+
+1. **Investigate phase-deferral first** (analysis, low-risk, likely biggest win):
+   trace whether per-bin `std::arg` can be safely deferred to only the tone bins
+   that `fa_phase` reads. Watch out: the stored phase is the AVERAGE arg across
+   navg rows — deferring requires the raw per-row FFT data still be available at
+   the point phase is needed (it currently is, in the navg>1 `tmp` buffer inside
+   `fft()`, but that buffer is local and freed). Determine feasibility +
+   correctness impact on existing metrics/tests.
+2. **Then build a reduce_and_scale optimization-ladder spike** (mirror the window
+   one): T0 baseline -> T1 drop/defer phase (algorithmic) -> T2 vectorized
+   atan2/sincos (AVX-256 polynomial, SLEEF-style) -> T3 hand-tuned asm -> T4
+   multicore. Verify each vs T0 within tolerance; report Msamples/s + attribution.
+
+## Branch / git status
+
+- Branch `bench/bh-window-asm`, ~12 commits (window spike + profiling commit
+  `97741bd`). Working tree clean; `src/` unmodified; `build/` gitignored;
+  `bench/profile/profile_pipeline` binary gitignored.
+- **PR:** being pushed/opened for the window spike + profiling (per decision
+  2026-06-22). Check `gh pr list` / the branch on the remote.
+
+## How to rebuild from cold
+
+```sh
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
+# window spike:
+bench/build.sh && bench/bh_window_bench
+# real library (for profiling driver):
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
+cmake --build build -j$(nproc)
+# profiling driver (needs the stage-timer instrumentation re-added to
+# src/fourier_transforms.cpp fft() if you want the per-stage breakdown again —
+# see bench/profile/PROFILE.md for exactly what to wrap):
+g++ -O3 -std=c++17 -Iinclude bench/profile/profile_pipeline.cpp \
+    -o bench/profile/profile_pipeline \
+    -Lbuild/bindings/c/src -lgenalyzer -Wl,-rpath,$PWD/build/bindings/c/src
+LD_LIBRARY_PATH=build/bindings/c/src GEN_PROFILE=1 \
+    bench/profile/profile_pipeline 65536 8 1.0
+```

--- a/docs/superpowers/plans/2026-06-19-blackman-harris-window-asm-benchmark.md
+++ b/docs/superpowers/plans/2026-06-19-blackman-harris-window-asm-benchmark.md
@@ -1,0 +1,641 @@
+# Blackman-Harris Window Optimization-Ladder Benchmark Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone benchmark that reimplements the genalyzer Blackman-Harris complex-FFT window function at five escalating optimization tiers (baseline → no-transcendentals → AVX intrinsics → hand-tuned assembly → multithreaded assembly) and reports the per-tier speedup ceiling on this AVX-256 machine.
+
+**Architecture:** A self-contained `bench/` directory built by a `build.sh` one-liner — no CMake, no changes to `src/`. One C++ translation unit holds the harness plus the C++ tiers (T0–T2, T4 driver); one `.S` file holds the AVX-256 assembly apply kernel (T3/T4). The harness generates fixed-seed random I/Q input, runs every tier on identical data, checks each tier's output against the T0 baseline (max-abs-err < 1e-9), times each (best-of-N, warm-up discarded), and prints a results table plus an attribution summary.
+
+**Tech Stack:** C++17, g++ 13.3, AVX-256 intrinsics (`<immintrin.h>`, `-mavx`, **no FMA/AVX2**), GAS AT&T-syntax assembly, `std::thread`, `std::chrono`.
+
+---
+
+## Background facts the implementer needs
+
+- Target function (faithful reference): `src/fourier_transforms.cpp:35` — the **complex-FFT** Blackman-Harris path. Per sample index `i` (`x = (double)i`):
+  ```
+  w        = bh_k0 + bh_k1*cos(k1*x) + bh_k2*cos(2*k1*x) + bh_k3*cos(3*k1*x)
+  out[2i]   = w * scalar * i_data[i*in_stride]
+  out[2i+1] = w * scalar * q_data[i*in_stride]
+  ```
+  where `scalar = bh_kx`, `k1 = 2*pi/nfft`. For `navg > 1` the *same* window applies to every row; row `k`'s input sample is `i_data[k*nfft*in_stride + i*in_stride]` and output is `out[k*nfft*2 + 2i]`.
+- Constants (copied from `src/fourier_transforms.cpp`):
+  `bh_kx = 1.9688861870585801`, `bh_k0 = 0.35875`, `bh_k1 = -0.48829`, `bh_k2 = 0.14128`, `bh_k3 = -0.01168`.
+- `real_t` in the library is `double`. The benchmark uses `double` directly and includes **no** library headers — it is fully standalone.
+- The workload always uses `in_stride = 1`, and input is laid out as `navg` contiguous rows of `nfft` samples (so row `k`, sample `i` = `data[k*nfft + i]`).
+- **Key optimization the ladder exploits:** the window vector is data-independent and identical across all `navg` rows, yet T0 recomputes 3 `std::cos` per sample. T1+ precompute a **scaled** window vector `sw[i] = bh_kx * w(i)` once, then the apply is just `out[2i] = sw[i]*I[i]`, `out[2i+1] = sw[i]*Q[i]`.
+- All benchmarked `nfft` values (4096, 65536, 1048576) are multiples of 4, so the SIMD/asm kernels may assume `nfft % 4 == 0`.
+
+## File structure
+
+```
+bench/
+  build.sh              # standalone g++ build (T0–T2 in .cpp, T3/T4 kernel in .S)
+  bh_window_bench.cpp   # harness: constants, reference, tiers T0/T1/T2/T4-driver,
+                        #          correctness check, timing, config sweep, reporting
+  bh_window_asm.S       # AVX-256 assembly apply kernel: bh_apply_asm (used by T3 and T4)
+  README.md             # how to build/run + captured results table + attribution
+```
+
+All tiers share one apply contract once the window exists. The signature every tier exposes to the harness is:
+
+```cpp
+using window_fn = void(*)(const double* I, const double* Q, double* out,
+                          size_t in_stride, size_t navg, size_t nfft);
+```
+
+---
+
+## Task 1: Scaffold harness + T0 baseline + build
+
+**Files:**
+- Create: `bench/bh_window_bench.cpp`
+- Create: `bench/build.sh`
+- Create: `bench/bh_window_asm.S` (empty-but-valid stub so the build links from the start)
+
+- [ ] **Step 1: Create the assembly stub so the build links**
+
+`bench/bh_window_asm.S`:
+```asm
+# AVX-256 apply kernel lives here (filled in Task 4). Empty stub for now.
+.section .note.GNU-stack,"",@progbits
+```
+
+- [ ] **Step 2: Write the harness with T0 baseline, an independent reference, correctness check, and a tiny self-test in main**
+
+`bench/bh_window_bench.cpp`:
+```cpp
+// Standalone benchmark for the genalyzer Blackman-Harris complex-FFT window.
+// Build: ./build.sh   Run: ./bh_window_bench
+#include <cstddef>
+#include <cstdio>
+#include <cmath>
+#include <vector>
+#include <random>
+#include <chrono>
+#include <string>
+
+using std::size_t;
+
+// ---- Blackman-Harris constants (from src/fourier_transforms.cpp) ----
+static const double bh_kx = 1.9688861870585801;
+static const double bh_k0 = 0.35875;
+static const double bh_k1 = -0.48829;
+static const double bh_k2 = 0.14128;
+static const double bh_k3 = -0.01168;
+static const double k_2pi = 6.283185307179586476925286766559;
+
+using window_fn = void (*)(const double*, const double*, double*,
+                           size_t, size_t, size_t);
+
+// ---- T0: baseline, faithful to src/fourier_transforms.cpp:35 ----
+// (navg>=2 branches in the original are an unrolled but behaviorally identical
+// path; collapsed here into one general loop.)
+void bh_window_t0(const double* i_data, const double* q_data, double* out_data,
+                  size_t in_stride, size_t navg, size_t nfft) {
+    const double scalar = bh_kx;
+    const double k1 = k_2pi / (double)nfft;
+    const double k2 = k1 * 2;
+    const double k3 = k1 * 3;
+    const size_t in_row_stride = nfft * in_stride;
+    const size_t out_row_stride = nfft * 2;
+    size_t i = 0;
+    double x = 0.0;
+    if (1 == navg) {
+        for (size_t j = 0; j < out_row_stride; j += 2) {
+            const double w = bh_k0 + bh_k1 * std::cos(k1 * x) +
+                             bh_k2 * std::cos(k2 * x) + bh_k3 * std::cos(k3 * x);
+            out_data[j] = w * scalar * i_data[i];
+            out_data[j + 1] = w * scalar * q_data[i];
+            i += in_stride;
+            x += 1.0;
+        }
+    } else {
+        for (size_t j = 0; j < out_row_stride; j += 2) {
+            const double w = bh_k0 + bh_k1 * std::cos(k1 * x) +
+                             bh_k2 * std::cos(k2 * x) + bh_k3 * std::cos(k3 * x);
+            const double* pi = i_data;
+            const double* pq = q_data;
+            double* po = out_data;
+            for (size_t k = 0; k < navg; ++k) {
+                po[j] = w * scalar * pi[i];
+                po[j + 1] = w * scalar * pq[i];
+                pi += in_row_stride;
+                pq += in_row_stride;
+                po += out_row_stride;
+            }
+            i += in_stride;
+            x += 1.0;
+        }
+    }
+}
+
+// ---- Independent reference (different arrangement) to anchor T0 ----
+void bh_window_ref(const double* i_data, const double* q_data, double* out,
+                   size_t in_stride, size_t navg, size_t nfft) {
+    for (size_t k = 0; k < navg; ++k) {
+        for (size_t i = 0; i < nfft; ++i) {
+            const double x = (double)i;
+            const double w = bh_k0 + bh_k1 * std::cos(k_2pi * 1.0 * x / nfft) +
+                             bh_k2 * std::cos(k_2pi * 2.0 * x / nfft) +
+                             bh_k3 * std::cos(k_2pi * 3.0 * x / nfft);
+            const double si = i_data[k * nfft * in_stride + i * in_stride];
+            const double sq = q_data[k * nfft * in_stride + i * in_stride];
+            out[k * nfft * 2 + 2 * i] = w * bh_kx * si;
+            out[k * nfft * 2 + 2 * i + 1] = w * bh_kx * sq;
+        }
+    }
+}
+
+double max_abs_err(const double* a, const double* b, size_t n) {
+    double m = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+        double d = std::fabs(a[i] - b[i]);
+        if (d > m) m = d;
+    }
+    return m;
+}
+
+int main() {
+    // Tiny anchored self-test: T0 vs the independent reference.
+    const size_t nfft = 16, navg = 2, in_stride = 1;
+    std::mt19937_64 rng(12345);
+    std::uniform_real_distribution<double> dist(-1.0, 1.0);
+    std::vector<double> I(nfft * navg), Q(nfft * navg);
+    for (size_t n = 0; n < I.size(); ++n) { I[n] = dist(rng); Q[n] = dist(rng); }
+    std::vector<double> out0(nfft * navg * 2), outr(nfft * navg * 2);
+    bh_window_t0(I.data(), Q.data(), out0.data(), in_stride, navg, nfft);
+    bh_window_ref(I.data(), Q.data(), outr.data(), in_stride, navg, nfft);
+    double err = max_abs_err(out0.data(), outr.data(), out0.size());
+    std::printf("T0 anchor max-abs-err = %.3e -> %s\n", err,
+                err < 1e-12 ? "PASS" : "FAIL");
+    return err < 1e-12 ? 0 : 1;
+}
+```
+
+- [ ] **Step 3: Write the build script**
+
+`bench/build.sh`:
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+g++ -O3 -mavx -std=c++17 -pthread -c bh_window_bench.cpp -o bh_window_bench.o
+g++ -c bh_window_asm.S -o bh_window_asm.o
+g++ bh_window_bench.o bh_window_asm.o -o bh_window_bench -pthread
+echo "built ./bench/bh_window_bench"
+```
+
+- [ ] **Step 4: Build and run the anchor self-test**
+
+Run: `chmod +x bench/build.sh && bench/build.sh && bench/bh_window_bench`
+Expected: prints `T0 anchor max-abs-err = ...e-16 -> PASS` and exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/bh_window_bench.cpp bench/build.sh bench/bh_window_asm.S
+git commit -m "bench: scaffold BH window harness with T0 baseline + anchor"
+```
+
+---
+
+## Task 2: T1 — no-transcendentals (precomputed window via phasor recurrence)
+
+**Files:**
+- Modify: `bench/bh_window_bench.cpp` (add `gen_scaled_window`, `bh_window_t1`; register in a tiers table and a correctness loop in `main`)
+
+- [ ] **Step 1: Add a stubbed T1 and a correctness loop that FAILS**
+
+Add above `main` in `bench/bh_window_bench.cpp`:
+```cpp
+// Generate sw[i] = bh_kx * window(i), i = 0..nfft-1, with NO per-sample
+// transcendentals: advance three complex phasors (for the 1st/2nd/3rd harmonic)
+// and renormalize every 1024 samples to bound floating-point drift.
+void gen_scaled_window(double* sw, size_t nfft) {
+    const double th = k_2pi / (double)nfft;
+    const double cz1 = std::cos(th),     sz1 = std::sin(th);
+    const double cz2 = std::cos(2 * th), sz2 = std::sin(2 * th);
+    const double cz3 = std::cos(3 * th), sz3 = std::sin(3 * th);
+    double c1 = 1, s1 = 0, c2 = 1, s2 = 0, c3 = 1, s3 = 0;
+    for (size_t i = 0; i < nfft; ++i) {
+        sw[i] = bh_kx * (bh_k0 + bh_k1 * c1 + bh_k2 * c2 + bh_k3 * c3);
+        double nc1 = c1 * cz1 - s1 * sz1, ns1 = c1 * sz1 + s1 * cz1; c1 = nc1; s1 = ns1;
+        double nc2 = c2 * cz2 - s2 * sz2, ns2 = c2 * sz2 + s2 * cz2; c2 = nc2; s2 = ns2;
+        double nc3 = c3 * cz3 - s3 * sz3, ns3 = c3 * sz3 + s3 * cz3; c3 = nc3; s3 = ns3;
+        if (((i + 1) & 1023) == 0) {
+            double x = (double)(i + 1);
+            c1 = std::cos(th * x);     s1 = std::sin(th * x);
+            c2 = std::cos(2 * th * x); s2 = std::sin(2 * th * x);
+            c3 = std::cos(3 * th * x); s3 = std::sin(3 * th * x);
+        }
+    }
+}
+
+// T1: precompute scaled window once, then scalar apply across all navg rows.
+void bh_window_t1(const double* i_data, const double* q_data, double* out_data,
+                  size_t in_stride, size_t navg, size_t nfft) {
+    static thread_local std::vector<double> sw;
+    sw.resize(nfft);
+    gen_scaled_window(sw.data(), nfft);
+    const size_t in_row_stride = nfft * in_stride;
+    const size_t out_row_stride = nfft * 2;
+    for (size_t k = 0; k < navg; ++k) {
+        const double* pi = i_data + k * in_row_stride;
+        const double* pq = q_data + k * in_row_stride;
+        double* po = out_data + k * out_row_stride;
+        for (size_t i = 0; i < nfft; ++i) {
+            po[2 * i] = sw[i] * pi[i * in_stride];
+            po[2 * i + 1] = sw[i] * pq[i * in_stride];
+        }
+    }
+}
+```
+
+Replace the body of `main` (keep the anchor test, then add a tier-correctness loop) with:
+```cpp
+int main() {
+    const size_t in_stride = 1;
+    struct Tier { const char* name; window_fn fn; };
+    Tier tiers[] = {
+        {"T0 baseline", bh_window_t0},
+        {"T1 no-trig ", bh_window_t1},
+    };
+
+    // Anchor T0 against the independent reference on a small case.
+    {
+        const size_t nfft = 16, navg = 2;
+        std::mt19937_64 rng(12345);
+        std::uniform_real_distribution<double> dist(-1.0, 1.0);
+        std::vector<double> I(nfft * navg), Q(nfft * navg);
+        for (size_t n = 0; n < I.size(); ++n) { I[n] = dist(rng); Q[n] = dist(rng); }
+        std::vector<double> a(nfft * navg * 2), b(nfft * navg * 2);
+        bh_window_t0(I.data(), Q.data(), a.data(), in_stride, navg, nfft);
+        bh_window_ref(I.data(), Q.data(), b.data(), in_stride, navg, nfft);
+        double e = max_abs_err(a.data(), b.data(), a.size());
+        std::printf("anchor: T0 vs ref max-abs-err = %.3e -> %s\n", e,
+                    e < 1e-12 ? "PASS" : "FAIL");
+        if (!(e < 1e-12)) return 1;
+    }
+
+    // Correctness: every tier vs T0 on a representative case.
+    {
+        const size_t nfft = 65536, navg = 8;
+        std::mt19937_64 rng(777);
+        std::uniform_real_distribution<double> dist(-1.0, 1.0);
+        std::vector<double> I(nfft * navg), Q(nfft * navg);
+        for (size_t n = 0; n < I.size(); ++n) { I[n] = dist(rng); Q[n] = dist(rng); }
+        std::vector<double> ref(nfft * navg * 2), got(nfft * navg * 2);
+        bh_window_t0(I.data(), Q.data(), ref.data(), in_stride, navg, nfft);
+        for (const Tier& t : tiers) {
+            std::fill(got.begin(), got.end(), 0.0);
+            t.fn(I.data(), Q.data(), got.data(), in_stride, navg, nfft);
+            double e = max_abs_err(ref.data(), got.data(), ref.size());
+            std::printf("correctness: %s max-abs-err = %.3e -> %s\n",
+                        t.name, e, e < 1e-9 ? "PASS" : "FAIL");
+            if (!(e < 1e-9)) return 1;
+        }
+    }
+    return 0;
+}
+```
+Add `#include <algorithm>` near the top includes for `std::fill`.
+
+- [ ] **Step 2: Build and run — confirm T1 PASSES correctness**
+
+Run: `bench/build.sh && bench/bh_window_bench`
+Expected: `anchor ... PASS`, `correctness: T0 baseline ... PASS`, `correctness: T1 no-trig ... PASS` (T1 err ~1e-13 or smaller).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bench/bh_window_bench.cpp
+git commit -m "bench: add T1 no-transcendentals tier (phasor recurrence)"
+```
+
+---
+
+## Task 3: T2 — AVX-256 intrinsics apply
+
+**Files:**
+- Modify: `bench/bh_window_bench.cpp` (add `bh_window_t2` using `<immintrin.h>`; register in `tiers`)
+
+- [ ] **Step 1: Add T2 (vectorized interleaved apply) and register it**
+
+Add `#include <immintrin.h>` to the includes. Add above `main`:
+```cpp
+// T2: shared precomputed window, AVX-256 apply. Processes 4 samples/iter.
+// For samples i..i+3: ri = sw*I, rq = sw*Q, then interleave to
+// out = r0,q0,r1,q1,r2,q2,r3,q3. nfft assumed multiple of 4.
+void bh_window_t2(const double* i_data, const double* q_data, double* out_data,
+                  size_t in_stride, size_t navg, size_t nfft) {
+    static thread_local std::vector<double> sw;
+    sw.resize(nfft);
+    gen_scaled_window(sw.data(), nfft);
+    const size_t in_row_stride = nfft * in_stride;  // in_stride==1 in workload
+    const size_t out_row_stride = nfft * 2;
+    for (size_t k = 0; k < navg; ++k) {
+        const double* pi = i_data + k * in_row_stride;
+        const double* pq = q_data + k * in_row_stride;
+        double* po = out_data + k * out_row_stride;
+        for (size_t i = 0; i < nfft; i += 4) {
+            __m256d w  = _mm256_loadu_pd(sw.data() + i);
+            __m256d vi = _mm256_loadu_pd(pi + i);
+            __m256d vq = _mm256_loadu_pd(pq + i);
+            __m256d ri = _mm256_mul_pd(w, vi);   // r0 r1 r2 r3
+            __m256d rq = _mm256_mul_pd(w, vq);   // q0 q1 q2 q3
+            __m256d lo = _mm256_unpacklo_pd(ri, rq);  // r0 q0 r2 q2
+            __m256d hi = _mm256_unpackhi_pd(ri, rq);  // r1 q1 r3 q3
+            __m256d o0 = _mm256_permute2f128_pd(lo, hi, 0x20); // r0 q0 r1 q1
+            __m256d o1 = _mm256_permute2f128_pd(lo, hi, 0x31); // r2 q2 r3 q3
+            _mm256_storeu_pd(po + 2 * i, o0);
+            _mm256_storeu_pd(po + 2 * i + 4, o1);
+        }
+    }
+}
+```
+Add `{"T2 avx-intr", bh_window_t2},` to the `tiers[]` array in `main`.
+
+- [ ] **Step 2: Build and run — confirm T2 PASSES correctness**
+
+Run: `bench/build.sh && bench/bh_window_bench`
+Expected: `correctness: T2 avx-intr max-abs-err = ...e-13 -> PASS`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bench/bh_window_bench.cpp
+git commit -m "bench: add T2 AVX-256 intrinsics tier"
+```
+
+---
+
+## Task 4: T3 — hand-tuned AVX-256 assembly apply (single core)
+
+**Files:**
+- Modify: `bench/bh_window_asm.S` (implement `bh_apply_asm`)
+- Modify: `bench/bh_window_bench.cpp` (declare `extern "C"` kernel, add `bh_window_t3`, register it)
+
+- [ ] **Step 1: Implement the assembly apply kernel**
+
+Replace `bench/bh_window_asm.S` with:
+```asm
+    .text
+    .globl bh_apply_asm
+    .type  bh_apply_asm, @function
+# void bh_apply_asm(const double* sw, const double* I, const double* Q,
+#                   double* out, size_t nfft)   // nfft multiple of 4
+# rdi=sw  rsi=I  rdx=Q  rcx=out  r8=nfft
+bh_apply_asm:
+    xor     %rax, %rax                 # rax = sample index i
+.Lloop:
+    cmp     %r8, %rax
+    jae     .Ldone
+    vmovupd (%rdi,%rax,8), %ymm0        # sw[i..i+3]
+    vmovupd (%rsi,%rax,8), %ymm1        # I[i..i+3]
+    vmovupd (%rdx,%rax,8), %ymm2        # Q[i..i+3]
+    vmulpd  %ymm1, %ymm0, %ymm1         # ri = sw*I  (r0 r1 r2 r3)
+    vmulpd  %ymm2, %ymm0, %ymm2         # rq = sw*Q  (q0 q1 q2 q3)
+    vunpcklpd %ymm2, %ymm1, %ymm3       # r0 q0 r2 q2
+    vunpckhpd %ymm2, %ymm1, %ymm4       # r1 q1 r3 q3
+    vperm2f128 $0x20, %ymm4, %ymm3, %ymm5   # r0 q0 r1 q1
+    vperm2f128 $0x31, %ymm4, %ymm3, %ymm6   # r2 q2 r3 q3
+    lea     (%rax,%rax,1), %r9          # r9 = 2*i  (out is interleaved)
+    vmovupd %ymm5, (%rcx,%r9,8)         # out[2i .. 2i+3]
+    vmovupd %ymm6, 32(%rcx,%r9,8)       # out[2i+4 .. 2i+7]
+    add     $4, %rax
+    jmp     .Lloop
+.Ldone:
+    vzeroupper
+    ret
+    .size  bh_apply_asm, .-bh_apply_asm
+.section .note.GNU-stack,"",@progbits
+```
+
+- [ ] **Step 2: Declare the kernel and add T3 driver in the harness**
+
+Add near the top of `bench/bh_window_bench.cpp` (after includes):
+```cpp
+extern "C" void bh_apply_asm(const double* sw, const double* I,
+                             const double* Q, double* out, size_t nfft);
+```
+Add above `main`:
+```cpp
+// T3: shared precomputed window, assembly apply kernel, single core.
+void bh_window_t3(const double* i_data, const double* q_data, double* out_data,
+                  size_t in_stride, size_t navg, size_t nfft) {
+    static thread_local std::vector<double> sw;
+    sw.resize(nfft);
+    gen_scaled_window(sw.data(), nfft);
+    const size_t in_row_stride = nfft * in_stride;
+    const size_t out_row_stride = nfft * 2;
+    for (size_t k = 0; k < navg; ++k) {
+        bh_apply_asm(sw.data(), i_data + k * in_row_stride,
+                     q_data + k * in_row_stride, out_data + k * out_row_stride,
+                     nfft);
+    }
+}
+```
+Add `{"T3 asm-1core", bh_window_t3},` to `tiers[]`.
+
+- [ ] **Step 3: Build and run — confirm T3 PASSES correctness**
+
+Run: `bench/build.sh && bench/bh_window_bench`
+Expected: `correctness: T3 asm-1core max-abs-err = ...e-13 -> PASS`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bench/bh_window_asm.S bench/bh_window_bench.cpp
+git commit -m "bench: add T3 hand-tuned AVX-256 assembly tier (single core)"
+```
+
+---
+
+## Task 5: T4 — multithreaded assembly apply
+
+**Files:**
+- Modify: `bench/bh_window_bench.cpp` (add `bh_window_t4` using `std::thread`; register it)
+
+- [ ] **Step 1: Add T4 (window generated once, apply split across 6 threads)**
+
+Add `#include <thread>` to includes. Add above `main`:
+```cpp
+// T4: precompute window once, then run the asm apply kernel on disjoint
+// row-chunks across NTHREADS physical cores.
+static const unsigned NTHREADS = 6;  // E5-1650 physical cores
+void bh_window_t4(const double* i_data, const double* q_data, double* out_data,
+                  size_t in_stride, size_t navg, size_t nfft) {
+    static thread_local std::vector<double> sw;
+    sw.resize(nfft);
+    gen_scaled_window(sw.data(), nfft);
+    const size_t in_row_stride = nfft * in_stride;
+    const size_t out_row_stride = nfft * 2;
+
+    auto apply_rows = [&](size_t k0, size_t k1) {
+        for (size_t k = k0; k < k1; ++k)
+            bh_apply_asm(sw.data(), i_data + k * in_row_stride,
+                         q_data + k * in_row_stride,
+                         out_data + k * out_row_stride, nfft);
+    };
+
+    if (navg >= NTHREADS) {
+        // Partition by rows.
+        std::vector<std::thread> ts;
+        size_t per = (navg + NTHREADS - 1) / NTHREADS;
+        for (unsigned t = 0; t < NTHREADS; ++t) {
+            size_t k0 = t * per, k1 = std::min(navg, k0 + per);
+            if (k0 >= k1) break;
+            ts.emplace_back(apply_rows, k0, k1);
+        }
+        for (auto& th : ts) th.join();
+    } else {
+        // Few rows: partition the single/large row's sample range instead.
+        std::vector<std::thread> ts;
+        size_t chunk = ((nfft / NTHREADS) / 4) * 4;  // keep multiple of 4
+        if (chunk == 0) chunk = nfft;
+        for (size_t k = 0; k < navg; ++k) {
+            for (size_t i0 = 0; i0 < nfft; i0 += chunk) {
+                size_t n = std::min(chunk, nfft - i0);
+                const double* pi = i_data + k * in_row_stride + i0 * in_stride;
+                const double* pq = q_data + k * in_row_stride + i0 * in_stride;
+                double* po = out_data + k * out_row_stride + 2 * i0;
+                const double* swp = sw.data() + i0;
+                ts.emplace_back([=] { bh_apply_asm(swp, pi, pq, po, n); });
+                if (ts.size() == NTHREADS) { for (auto& th : ts) th.join(); ts.clear(); }
+            }
+        }
+        for (auto& th : ts) th.join();
+    }
+}
+```
+Add `{"T4 asm-6core", bh_window_t4},` to `tiers[]`.
+
+Note: the sample-range partition relies on `nfft % 4 == 0` and `chunk % 4 == 0` so every `bh_apply_asm` call gets a multiple-of-4 length — true for all workload sizes.
+
+- [ ] **Step 2: Build and run — confirm T4 PASSES correctness**
+
+Run: `bench/build.sh && bench/bh_window_bench`
+Expected: `correctness: T4 asm-6core max-abs-err = ...e-13 -> PASS`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bench/bh_window_bench.cpp
+git commit -m "bench: add T4 multithreaded assembly tier"
+```
+
+---
+
+## Task 6: Config sweep, timing, results table, README
+
+**Files:**
+- Modify: `bench/bh_window_bench.cpp` (add timing + sweep + table to `main`)
+- Create: `bench/README.md`
+
+- [ ] **Step 1: Add a timing helper and a sweep+report block to `main`**
+
+Add `#include <cstdint>` and `<chrono>` (already present) usage. Add above `main`:
+```cpp
+// Best Msamples/s over repeated runs totaling >= min_sec (warm-up discarded).
+double bench_msps(window_fn fn, const double* I, const double* Q, double* out,
+                  size_t in_stride, size_t navg, size_t nfft, double min_sec) {
+    fn(I, Q, out, in_stride, navg, nfft);  // warm-up
+    using clk = std::chrono::steady_clock;
+    double best = 0.0, elapsed = 0.0;
+    auto t0 = clk::now();
+    const double samples = (double)nfft * (double)navg;
+    while (elapsed < min_sec) {
+        auto a = clk::now();
+        fn(I, Q, out, in_stride, navg, nfft);
+        auto b = clk::now();
+        double dt = std::chrono::duration<double>(b - a).count();
+        double msps = samples / dt / 1e6;
+        if (msps > best) best = msps;
+        elapsed = std::chrono::duration<double>(b - t0).count();
+    }
+    return best;
+}
+```
+
+After the correctness block in `main` (before `return 0;`), add:
+```cpp
+    // ---- Timing sweep ----
+    struct Cfg { size_t nfft, navg; };
+    Cfg cfgs[] = {
+        {4096, 1}, {4096, 8},
+        {65536, 1}, {65536, 8},
+        {1048576, 1}, {1048576, 8},
+    };
+    std::printf("\n%-12s %9s %6s %12s %10s %12s\n",
+                "tier", "nfft", "navg", "Msamples/s", "speedup", "max-abs-err");
+    std::mt19937_64 rng(2024);
+    std::uniform_real_distribution<double> dist(-1.0, 1.0);
+    for (const Cfg& c : cfgs) {
+        std::vector<double> I(c.nfft * c.navg), Q(c.nfft * c.navg);
+        for (size_t n = 0; n < I.size(); ++n) { I[n] = dist(rng); Q[n] = dist(rng); }
+        std::vector<double> ref(c.nfft * c.navg * 2), got(c.nfft * c.navg * 2);
+        bh_window_t0(I.data(), Q.data(), ref.data(), in_stride, c.navg, c.nfft);
+        double base_msps = 0.0;
+        for (const Tier& t : tiers) {
+            std::fill(got.begin(), got.end(), 0.0);
+            t.fn(I.data(), Q.data(), got.data(), in_stride, c.navg, c.nfft);
+            double e = max_abs_err(ref.data(), got.data(), ref.size());
+            double msps = bench_msps(t.fn, I.data(), Q.data(), got.data(),
+                                     in_stride, c.navg, c.nfft, 0.5);
+            if (&t == &tiers[0]) base_msps = msps;
+            std::printf("%-12s %9zu %6zu %12.1f %9.2fx %12.2e\n",
+                        t.name, c.nfft, c.navg, msps, msps / base_msps, e);
+        }
+        std::printf("\n");
+    }
+    return 0;
+```
+
+- [ ] **Step 2: Build, run, and capture the results**
+
+Run: `bench/build.sh && bench/bh_window_bench | tee bench/results.txt`
+Expected: anchor PASS, all correctness PASS, then a table with six config blocks; T0 speedup column reads `1.00x`, and T1–T4 show increasing Msamples/s.
+
+- [ ] **Step 3: Write the README with build/run instructions and the captured table**
+
+Create `bench/README.md`. Paste the actual table from `bench/results.txt` into the Results section and write a 1-paragraph attribution summary covering: how much came from killing transcendentals (T1 vs T0), from AVX intrinsics (T2 vs T1), from hand-tuned assembly (T3 vs T2), and from threading (T4 vs T3); plus the observation that at `navg=1` window *generation* dominates (so apply-side SIMD/asm shows less there) while at `navg=8` the apply-side tiers separate. Use this skeleton:
+```markdown
+# Blackman-Harris Window Optimization-Ladder Benchmark
+
+Standalone spike measuring the speed ceiling of the genalyzer Blackman-Harris
+complex-FFT window on this AVX-256 (no-FMA) Xeon E5-1650, 6 cores.
+
+## Build & run
+    ./build.sh
+    ./bh_window_bench
+
+## Tiers
+- T0 baseline  — std::cos x3 per sample (copy of src/fourier_transforms.cpp:35)
+- T1 no-trig   — precomputed window via phasor recurrence, scalar apply
+- T2 avx-intr  — AVX-256 intrinsics apply
+- T3 asm-1core — hand-tuned AVX-256 assembly apply
+- T4 asm-6core — assembly apply split across 6 cores
+
+## Results
+<paste table from results.txt>
+
+## Attribution
+<1 paragraph: where the speedup came from at each rung; navg=1 vs navg=8 note>
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bench/bh_window_bench.cpp bench/README.md bench/results.txt
+git commit -m "bench: add timing sweep, results table, and README"
+```
+
+---
+
+## Self-review notes (already applied)
+
+- **Spec coverage:** T0–T4 tiers ✓ (Tasks 1–5); workload sweep nfft∈{4096,65536,1048576} × navg∈{1,8} ✓ (Task 6); correctness max-abs-err<1e-9 vs T0 ✓ (Tasks 2–6); Msamples/s + speedup + attribution ✓ (Task 6); standalone build, no src/ changes ✓ (Task 1); AVX-256 no-FMA target ✓ (`-mavx`, asm uses only AVX1 ops). Success-criteria headline numbers come from the Task 6 table.
+- **Type consistency:** every tier matches `window_fn` (`const double*, const double*, double*, size_t, size_t, size_t`); `gen_scaled_window` and `bh_apply_asm` signatures are identical at definition and all call sites; `Tier`/`Cfg` structs defined before use in `main`.
+- **No placeholders:** all code blocks complete; the only intentionally human-filled artifact is the captured results table + attribution paragraph in the README (Task 6 Step 3), which require the actual run output.
+```

--- a/docs/superpowers/specs/2026-06-19-blackman-harris-window-asm-design.md
+++ b/docs/superpowers/specs/2026-06-19-blackman-harris-window-asm-design.md
@@ -1,0 +1,139 @@
+# Blackman-Harris Window Optimization-Ladder Benchmark — Design
+
+**Date:** 2026-06-19
+**Status:** Approved design, ready for implementation plan
+**Goal:** Exploration / "how fast can we make it" — a research spike to find the
+speed ceiling of the spectral-analysis window function via hand-tuned assembly.
+Throwaway, non-portable code is acceptable; the deliverable is *knowledge*
+(an upper-bound speedup number with per-technique attribution), not merged
+library code.
+
+## Scope
+
+In scope: the **Blackman-Harris window, complex-FFT path** only — the function at
+`src/fourier_transforms.cpp:35`:
+
+```cpp
+void blackman_harris(const real_t *i_data, const real_t *q_data,
+        real_t *out_data, size_t in_stride, size_t navg, size_t nfft);
+```
+
+It produces interleaved I/Q output where, for sample index `i` and output index
+`j = 2i`:
+
+```
+w        = bh_k0 + bh_k1*cos(k1*x) + bh_k2*cos(2*k1*x) + bh_k3*cos(3*k1*x)
+out[j]   = w * scalar * i_data[i*in_stride]
+out[j+1] = w * scalar * q_data[i*in_stride]
+```
+
+with `x = 0,1,...,nfft-1`, `k1 = 2*pi/nfft`, and the window coefficients/scalar
+defined in `fourier_transforms.cpp`. The same `w` multiplies both I and Q. For
+`navg > 1` the *same* window vector applies to every averaged row.
+
+Out of scope: the real-FFT path, Hann, normalized/quantized window variants, the
+magnitude-reduction loop, the FFT itself (FFTW), and the analysis metrics. The
+harness is structured so the magnitude-reduction loop could be added later, but
+that is not part of this spike.
+
+## Key insight driving the design
+
+The window coefficients depend **only** on the bin index and `nfft`. They are
+independent of the input data and identical across all `navg` rows. The baseline
+nonetheless recomputes three `std::cos` calls per sample on every call. So the
+optimization ladder has real rungs *before* assembly: eliminating the
+transcendentals and precomputing the window vector once. The assembly tier is the
+top rung, and the harness attributes the speedup to each technique.
+
+## Hardware target
+
+Intel Xeon E5-1650 (Sandy Bridge-E): **AVX-256 (4 doubles wide), no AVX2, no FMA,
+no AVX-512**, 6 physical cores / 12 threads. All SIMD and assembly tiers target
+AVX-256 without FMA — that is this machine's ceiling. `real_t = double`.
+
+## Architecture
+
+A standalone benchmark executable in a new top-level `bench/` directory, built
+**independently** of the library via a `build.sh` one-liner (no CMake wiring, no
+changes to `src/`). Each optimization tier is a self-contained function with the
+identical signature to the real one. The harness:
+
+1. Generates random I/Q input once (fixed seed) plus the output buffers.
+2. Runs every tier on identical input.
+3. Verifies each tier's output against T0 (max abs/rel error).
+4. Times each tier (best-of-N, warm-up discarded).
+5. Prints a results table and a short attribution summary.
+
+## Optimization tiers
+
+- **T0 — Baseline.** Current `src/` code copied verbatim (`std::cos` x3 per
+  sample). Reference for correctness and speedup.
+- **T1 — Algorithmic, no transcendentals.** Generate the length-`nfft` window
+  vector once via a cosine recurrence
+  (`cos((n+1)θ) = 2cosθ·cos(nθ) − cos((n−1)θ)`, tracking the three harmonics),
+  then apply it. Reuse the window vector across all `navg` rows. Pure portable
+  C++.
+- **T2 — SIMD intrinsics.** AVX-256 (`__m256d`, 4 doubles/iteration, no FMA).
+  Vectorized window-apply (`w*scalar*data`); window generation precomputed
+  (T1-style) or polynomial-vectorized.
+- **T3 — Hand-tuned assembly, single core.** AVX-256 in a separate `.S`
+  translation unit — manual register allocation, loop unrolling, addressing
+  modes. The single-core ceiling.
+- **T4 — Hand-tuned assembly, multithreaded.** T3 partitioned across the 6
+  physical cores (e.g. `std::thread` splitting the sample range, calling the T3
+  asm kernel per chunk). The overall ceiling.
+
+## Workload
+
+Sweep over representative configurations:
+
+- `nfft ∈ {4096, 65536, 1048576}`
+- `navg ∈ {1, 8}` (navg=1 isolates per-sample window cost; navg=8 exercises the
+  window-vector reuse-across-rows win)
+- `in_stride = 1`
+
+Each (tier, config) runs enough iterations to total ≥ ~0.5 s of wall time;
+best-of-N reported to suppress noise.
+
+## Correctness
+
+Each tier's output is compared elementwise against T0. Report **max absolute
+error** and **max relative error** per config. A tier passes if max-abs-error
+< `1e-9`. Bit-exactness is neither expected nor required — the recurrence and
+SIMD/asm reorderings introduce sub-ULP-scale floating-point differences. (T4 must
+produce the same result as T3 regardless of thread count / partition boundaries.)
+
+## Measurement & reporting
+
+- Monotonic clock (`std::chrono::steady_clock` or `clock_gettime(CLOCK_MONOTONIC)`).
+- One warm-up iteration per (tier, config), discarded.
+- Single-core tiers (T0–T3) pinned to one core for stable numbers; T4 uses all 6.
+- Output table columns: `tier | nfft | navg | Msamples/s | speedup vs T0 |
+  max-abs-err`.
+- Followed by a one-paragraph attribution summary: how much speed came from
+  killing transcendentals (T1), from SIMD (T2), from hand assembly (T3), and from
+  threads (T4).
+
+## File layout
+
+```
+bench/
+  build.sh              # standalone g++ build, no CMake, no src/ changes
+  bh_window_bench.cpp   # harness + T0, T1, T2 tiers, correctness, timing, report
+  bh_window_asm.S       # T3 / T4 AVX-256 assembly kernel (separate TU)
+  README.md             # how to build/run + captured results table
+```
+
+## Success criteria
+
+- All tiers produce correct output (max-abs-err < 1e-9 vs T0) across all configs.
+- A results table with per-tier Msamples/s and speedup-vs-baseline is produced.
+- The attribution summary identifies where the speed came from at each rung.
+- A headline number: the maximum single-core (T3) and multicore (T4) speedup over
+  the current baseline for the Blackman-Harris complex-FFT window.
+
+## Non-goals
+
+- Merging any of this into the library or modifying `src/`.
+- Portability beyond the AVX-256 Sandy Bridge target.
+- Optimizing any function other than the Blackman-Harris complex-FFT window.


### PR DESCRIPTION
## Summary

Exploratory, self-contained performance spike under `bench/` (no `src/` changes) investigating how fast genalyzer's spectral-analysis math can go, down to hand-tuned AVX-256 assembly. Two pieces:

1. **Blackman-Harris window optimization ladder** (`bench/bh_window_bench.cpp`, `bench/bh_window_asm.S`): T0 baseline (`std::cos` ×3/sample) → T1 no-transcendentals (phasor recurrence) → T2 AVX-256 intrinsics → T3 hand-tuned asm → T4 multithreaded. Each tier verified vs T0 (max-abs-err < 1e-9).
2. **Real-pipeline profile** (`bench/profile/`): stage breakdown of the actual `fft()` path.

## Findings

- **Window:** the ~8–10× single-core speedup comes *entirely* from killing the transcendentals (T0→T1). SIMD (T2) and hand-tuned assembly (T3) add essentially nothing — once the data-independent window is precomputed, the apply loop is memory-bandwidth-bound. Multicore (T4) only wins at large nfft+navg.
- **Pipeline profile (the bigger result):** with averaging (navg>1), `reduce_and_scale` — the per-bin `std::arg`(atan2) + `std::polar`(sincos) stage — is **47–68% of the entire transform, 1.5–4.6× the FFT itself**. Since analysis consumes mean-square magnitude and only reads phase at a handful of tone bins, most of those `navg×nfft` atan2 calls appear to be wasted work. This is the next optimization target.

Build/run: `bench/build.sh && bench/bh_window_bench`. Details in `bench/README.md`, `bench/profile/PROFILE.md`, and the spec/plan/session-state docs under `docs/superpowers/`.

## Test Plan
- [x] All tier correctness gates pass (anchor + per-tier vs T0, incl. renorm-coverage)
- [x] No `src/` modifications (profiling instrumentation was temporary, reverted)
- [ ] Reviewer sanity-check of the AVX-256 asm kernel and profiling methodology

> Note: throwaway research spike for measurement/learning, not intended as production code.