### PR TITLE
doc/conf.py: add repository value

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,6 +23,7 @@ gen_pages()
 
 # -- Project information -----------------------------------------------------
 
+repository = "genalyzer"
 project = "Genalyzer"
 copyright = "2024-2026, Analog Devices, Inc."
 author = "Analog Devices, Inc."


### PR DESCRIPTION
To stamp the build with the repository name, used for the 'search' and 'edit page' features.

added to the lut too
https://github.com/analogdevicesinc/doctools/commit/5675f5c800a99e1ea9d2ed02487a9bb60ce77658
