### PR TITLE
Improve Python package READMEs

### DIFF
--- a/bindings/python-fftw/README.md
+++ b/bindings/python-fftw/README.md
@@ -1,4 +1,76 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/analogdevicesinc/genalyzer/main/doc/_static/genalyzer_logo.png" width="500" alt="Genalyzer">
+</p>
+
 # genalyzer-fftw
 
-Platform-native GPL runtime for `genalyzer`, including `libgenalyzer` and FFTW.
-Install with `pip install "genalyzer[fftw]"`. This distribution is GPL-2.0-or-later.
+GPL FFTW-enabled native runtime for the
+[`genalyzer`](https://pypi.org/project/genalyzer/) Python package.
+
+This package contains the platform-native `libgenalyzer` library built with FFTW
+support, plus the runtime FFTW libraries needed by the wheel. It is intentionally
+separate from the `genalyzer` Python API package so users can choose between the
+published GPL FFTW runtime and their own compatible native build.
+
+## Installation
+
+Most users should install this package through the `genalyzer` extra:
+
+```bash
+python -m pip install "genalyzer[fftw]"
+```
+
+Direct installation is also supported:
+
+```bash
+python -m pip install genalyzer genalyzer-fftw
+```
+
+The `genalyzer` Python package prefers the bundled runtime from
+`genalyzer-fftw`. If this package is not installed, `genalyzer` falls back to
+searching the system library path for a compatible `libgenalyzer`.
+
+## What This Package Provides
+
+- `libgenalyzer` built for the target platform.
+- Bundled FFTW runtime libraries required by `libgenalyzer`.
+- Wheel metadata and third-party notices for the GPL FFTW-enabled runtime.
+
+Published wheels are built for supported CPython and platform combinations via
+`cibuildwheel`.
+
+## Quick Smoke Test
+
+```python
+import numpy as np
+import genalyzer as gn
+
+samples = np.ones(8, dtype=np.complex128)
+result = gn.fft(samples, 1, 8, gn.Window.NO_WINDOW)
+
+np.testing.assert_allclose(result[0], 1)
+np.testing.assert_allclose(result[1:], 0, atol=1e-12)
+```
+
+## Licensing
+
+This distribution is `GPL-2.0-or-later`.
+
+The wheels bundle FFTW. FFTW is GPL unless a separate commercial FFTW license has
+been obtained, so the published FFTW-enabled runtime wheels use the project's
+GPL license option. The ADI BSD source license option does not apply to these
+published wheels.
+
+See the files shipped with this distribution for details:
+
+- `LICENSE`
+- `FFTW_COPYING`
+- `THIRD_PARTY_LICENSES.md`
+- `FFTW_SOURCE.md`
+
+## Links
+
+- Python API package: https://pypi.org/project/genalyzer/
+- Documentation: https://analogdevicesinc.github.io/genalyzer/
+- Source: https://github.com/analogdevicesinc/genalyzer
+- Support: https://ez.analog.com/sw-interface-tools/f/q-a

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,19 +1,101 @@
-# genalyzer: Python Bindings
+<p align="center">
+  <img src="https://raw.githubusercontent.com/analogdevicesinc/genalyzer/main/doc/_static/genalyzer_logo.png" width="500" alt="Genalyzer">
+</p>
 
-This package contains the python bindings for genalyzer, a library for computing data-converter performance metrics.
+# genalyzer
 
-## FFTW Binary Wheel Variants and Licensing
+Python bindings for Genalyzer, a converter-analysis library from Analog Devices
+for generating waveforms and computing data-converter performance metrics from
+time-domain or frequency-domain data.
 
-The platform-wheel variants built for supported Python and operating-system combinations link the native `libgenalyzer` library against FFTW and use wheel repair tools to bundle the required FFTW runtime. FFTW is GPL unless a separate commercial FFTW license has been obtained. The published FFTW-inclusive wheels therefore select the project's **GPL-2.0-or-later** license option, and their package metadata reports that license explicitly.
+Genalyzer provides Python access to the native `libgenalyzer` engine for common
+ADC and DAC analysis workflows, including waveform generation, quantization,
+histogram analysis, DNL/INL analysis, FFT processing, and Fourier performance
+metrics such as SNR, SINAD, SFDR, and harmonic distortion.
 
-The ADI BSD source license option does **not** apply to these wheels. It is available only when `libgenalyzer` is built with FFTW under a separate compatible commercial license, or with another FFT implementation/license arrangement that permits the ADI BSD terms. Such a non-GPL build must be distributed separately with matching metadata; it must not reuse the FFTW-wheel artifacts produced by this repository's CI. See `THIRD_PARTY_LICENSES.md`, shipped with each distribution, for the wheel-specific third-party notices.
+## Installation
+
+For the standard PyPI install with the bundled FFTW-enabled native runtime:
+
+```bash
+python -m pip install "genalyzer[fftw]"
+```
+
+This installs:
+
+- `genalyzer`: the Python API package.
+- `genalyzer-fftw`: the GPL FFTW-enabled native runtime package containing
+  `libgenalyzer` and its FFTW runtime dependencies.
+
+If you provide your own compatible `libgenalyzer` on the system library path,
+you can install only the Python API package:
+
+```bash
+python -m pip install genalyzer
+```
+
+## Quick Start
+
+```python
+import numpy as np
+import genalyzer as gn
+
+nfft = 1024
+fs = 1.0e9
+freq = gn.coherent(nfft, fs, 70.0e6)
+samples = gn.cos(nfft, fs, 0.9, freq, 0.0, 0.0, 0.0)
+codes = gn.quantize(samples, 2.0, 12, 0.0, gn.CodeFormat.TWOS_COMPLEMENT)
+spectrum = gn.fft(codes, 12, 1, nfft, gn.Window.NO_WINDOW, gn.CodeFormat.TWOS_COMPLEMENT)
+
+gn.mgr_remove("fa")
+gn.fa_create("fa")
+gn.fa_analysis_band("fa", "fdata*0.0", "fdata*1.0")
+gn.fa_fixed_tone("fa", "A", gn.FaCompTag.SIGNAL, freq, 0)
+gn.fa_fsample("fa", fs)
+gn.fa_fdata("fa", fs)
+
+results = gn.fft_analysis("fa", spectrum, nfft, gn.FreqAxisType.DC_CENTER)
+print(f"SFDR: {results['sfdr']:.2f} dB")
+```
 
 ## Optional Features
 
-To support pytest functionality, genalyzer includes pytest fixture to help manage plots and generate reports.
+Additional extras are available for common workflows:
 
-This is heavily based off [pytest-reporter-html1](https://github.com/christiansandberg/pytest-reporter-html1/tree/master). See [LICENSE](https://github.com/christiansandberg/pytest-reporter-html1/blob/master/LICENSE) for related licensing information. 
+```bash
+python -m pip install "genalyzer[fftw,tools]"
+python -m pip install "genalyzer[fftw,pytest]"
+python -m pip install "genalyzer[fftw,mcp]"
+```
 
-## Pytest Testing (of plugin)
+- `tools`: scientific helper dependencies such as SciPy.
+- `pytest`: the Genalyzer pytest plugin and report-generation dependencies.
+- `mcp`: the Genalyzer MCP server dependencies.
+- `cli`: command-line interface dependencies.
 
-Tests were heavily ported as well from [pytest-reporter-html1](https://github.com/christiansandberg/pytest-reporter-html1). File headers include attribution.
+The pytest plugin provides fixtures for attaching plots and analysis artifacts to
+test reports. It is based in part on
+[pytest-reporter-html1](https://github.com/christiansandberg/pytest-reporter-html1);
+the related license notice is included with the package.
+
+## Licensing
+
+The `genalyzer` Python API package is distributed with the license expression
+`LicenseRef-ADIBSD OR GPL-2.0-or-later`.
+
+The PyPI extra `genalyzer[fftw]` installs `genalyzer-fftw`, which bundles FFTW.
+FFTW is GPL unless a separate commercial FFTW license has been obtained, so the
+published FFTW-enabled runtime wheels are distributed as `GPL-2.0-or-later`.
+
+The ADI BSD source license option does not apply to the published
+FFTW-inclusive runtime wheels. It is available only when `libgenalyzer` is built
+with FFTW under a separate compatible commercial license, or with another FFT
+implementation/license arrangement that permits the ADI BSD terms. See
+`THIRD_PARTY_LICENSES.md`, shipped with each distribution, for third-party
+license details.
+
+## Links
+
+- Documentation: https://analogdevicesinc.github.io/genalyzer/
+- Source: https://github.com/analogdevicesinc/genalyzer
+- Support: https://ez.analog.com/sw-interface-tools/f/q-a


### PR DESCRIPTION
## Summary
- add the Genalyzer logo to the PyPI package READMEs
- expand the genalyzer README with install guidance, quick start, extras, licensing, and links
- expand the genalyzer-fftw README with runtime-package purpose, install guidance, smoke test, licensing, and links

## Verification
- python3 -m build in bindings/python
- python3 -m build in bindings/python-fftw
- git diff --check -- bindings/python/README.md bindings/python-fftw/README.md

Note: local twine check stops on existing PEP 639 metadata fields before README rendering: license-expression and license-file.